### PR TITLE
fix foundryup command readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ git clone --recurse-submodules https://github.com/prime-ai/prime-miner-validator
 git submodule update --init --recursive
 ```
 ## Setup:
-- Foundry: `curl -L https://foundry.paradigm.xyz | bash` - do not forget `foundry up`
+- Foundry: `curl -L https://foundry.paradigm.xyz | bash` - do not forget `foundryup`
 - Docker 
 - tmuxinator: Install via `gem install tmuxinator` - do not use brew, apparently their brew build is broken
 - Rust: Install via `curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh`


### PR DESCRIPTION
The command to install foundry sould be `foundryup` instead of `foundry up`

### before 
```
foundry up
zsh: command not found: foundry
```

### after
```
foundryup 


.xOx.xOx.xOx.xOx.xOx.xOx.xOx.xOx.xOx.xOx.xOx.xOx.xOx.xOx.xOx.xOx.xOx.xOx

 ╔═╗ ╔═╗ ╦ ╦ ╔╗╔ ╔╦╗ ╦═╗ ╦ ╦         Portable and modular toolkit
 ╠╣  ║ ║ ║ ║ ║║║  ║║ ╠╦╝ ╚╦╝    for Ethereum Application Development
 ╚   ╚═╝ ╚═╝ ╝╚╝ ═╩╝ ╩╚═  ╩                 written in Rust.

.xOx.xOx.xOx.xOx.xOx.xOx.xOx.xOx.xOx.xOx.xOx.xOx.xOx.xOx.xOx.xOx.xOx.xOx

Repo       : https://github.com/foundry-rs/foundry
Book       : https://book.getfoundry.sh/
Chat       : https://t.me/foundry_rs/
Support    : https://t.me/foundry_support/
Contribute : https://github.com/foundry-rs/foundry/blob/master/CONTRIBUTING.md

.xOx.xOx.xOx.xOx.xOx.xOx.xOx.xOx.xOx.xOx.xOx.xOx.xOx.xOx.xOx.xOx.xOx.xOx

foundryup: installing foundry (version stable, tag stable)
foundryup: downloading forge, cast, anvil, and chisel for stable version
```



## more context
Message from the curl foundry install 

```
 curl -L https://foundry.paradigm.xyz | bash
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   167  100   167    0     0   1050      0 --:--:-- --:--:-- --:--:--  1056
100  2196  100  2196    0     0   5734      0 --:--:-- --:--:-- --:--:--  5734
Installing foundryup...

Detected your preferred shell is zsh and added foundryup to PATH.
Run 'source /home/sami/.zshenv' or start a new terminal session to use foundryup.
Then, simply run 'foundryup' to install Foundry.
```
