### PR TITLE
use bash as default shell for make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+SHELL := /bin/bash
 ENV_FILE ?= .env
 .PHONY: setup pool domain fund
 


### PR DESCRIPTION
the current makefile config is not working with linux.  The sh shell does not have source on ubuntu (it does have it on mac OS) tho. Make is using sh as default shell, switching to bash as default fix it

```
bash -c 'tmux select-pane -T "Miner" && sleep 5 && make test-print-env'
make[1]: Entering directory '/home/sami/Workspace/pi/prime-miner-validator'
set -a; source .env; set +a; \
printenv | grep MIN_STAKE_AMOUNT
/bin/sh: 1: source: not found
make[1]: *** [Makefile:9: test-print-env] Error 1
make[1]: Leaving directory '/home/sami/Workspace/pi/prime-miner-validator'
```