### PR TITLE
Improvement: validator health loop link

### DIFF
--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -369,7 +369,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         LAST_LOOP_DURATION_MS.store(loop_duration_ms, Ordering::Relaxed);
 
         info!("Validation loop completed in {}ms", loop_duration_ms);
-        std::thread::sleep(std::time::Duration::from_secs(10));
+        tokio::time::sleep(std::time::Duration::from_secs(10)).await;
     }
     Ok(())
 }


### PR DESCRIPTION
Sometimes the validator got stuck in the past (which we def. have to fix) but this way K8s simply restarts the validator if it does not validate properly. 