### PR TITLE
orchestrator healthcheck depending on running threads

### DIFF
--- a/orchestrator/src/api/server.rs
+++ b/orchestrator/src/api/server.rs
@@ -24,6 +24,7 @@ pub struct AppState {
     pub heartbeats: Arc<LoopHeartbeats>,
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn start_server(
     host: &str,
     port: u16,

--- a/orchestrator/src/api/server.rs
+++ b/orchestrator/src/api/server.rs
@@ -4,6 +4,7 @@ use crate::api::routes::task::tasks_routes;
 use crate::api::routes::{heartbeat::heartbeat_routes, metrics::metrics_routes};
 use crate::models::node::NodeStatus;
 use crate::store::core::StoreContext;
+use crate::utils::loop_heartbeats::LoopHeartbeats;
 use actix_web::middleware::{Compress, NormalizePath, TrailingSlash};
 use actix_web::{middleware, web::Data, App, HttpServer};
 use actix_web::{web, HttpResponse};
@@ -20,6 +21,7 @@ pub struct AppState {
     pub wallet: Arc<Wallet>,
     pub s3_credentials: Option<String>,
     pub bucket_name: Option<String>,
+    pub heartbeats: Arc<LoopHeartbeats>,
 }
 
 pub async fn start_server(
@@ -30,6 +32,7 @@ pub async fn start_server(
     admin_api_key: String,
     s3_credentials: Option<String>,
     bucket_name: Option<String>,
+    heartbeats: Arc<LoopHeartbeats>,
 ) -> Result<(), Error> {
     info!("Starting server at http://{}:{}", host, port);
     let app_state = Data::new(AppState {
@@ -37,6 +40,7 @@ pub async fn start_server(
         wallet,
         s3_credentials,
         bucket_name,
+        heartbeats,
     });
     let node_store = app_state.store_context.node_store.clone();
     let node_store_clone = node_store.clone();
@@ -57,11 +61,16 @@ pub async fn start_server(
             .wrap(Compress::default())
             .wrap(NormalizePath::new(TrailingSlash::Trim))
             .app_data(web::PayloadConfig::default().limit(2_097_152))
-            .service(web::resource("/health").route(web::get().to(|| async {
-                HttpResponse::Ok().json(json!({
-                    "status": "ok"
-                }))
-            })))
+            .service(web::resource("/health").route(web::get().to(
+                |data: web::Data<AppState>| async move {
+                    let health_status = data.heartbeats.health_status();
+                    if health_status.healthy {
+                        HttpResponse::Ok().json(health_status)
+                    } else {
+                        HttpResponse::InternalServerError().json(health_status)
+                    }
+                },
+            )))
             .service(heartbeat_routes().wrap(ValidateSignature::new(validator_state.clone())))
             .service(storage_routes().wrap(ValidateSignature::new(validator_state.clone())))
             .service(nodes_routes().wrap(api_key_middleware.clone()))

--- a/orchestrator/src/api/tests/helper.rs
+++ b/orchestrator/src/api/tests/helper.rs
@@ -17,6 +17,8 @@ use url::Url;
 
 #[cfg(test)]
 pub async fn create_test_app_state() -> Data<AppState> {
+    use crate::utils::loop_heartbeats::LoopHeartbeats;
+
     let store = Arc::new(RedisStore::new_test());
     let mut con = store
         .client
@@ -42,6 +44,7 @@ pub async fn create_test_app_state() -> Data<AppState> {
         ),
         s3_credentials: None,
         bucket_name: None,
+        heartbeats: Arc::new(LoopHeartbeats::new()),
     })
 }
 

--- a/orchestrator/src/discovery/monitor.rs
+++ b/orchestrator/src/discovery/monitor.rs
@@ -1,6 +1,7 @@
 use crate::models::node::NodeStatus;
 use crate::models::node::OrchestratorNode;
 use crate::store::core::StoreContext;
+use crate::utils::loop_heartbeats::LoopHeartbeats;
 use alloy::primitives::Address;
 use anyhow::Error;
 use anyhow::Result;
@@ -20,6 +21,7 @@ pub struct DiscoveryMonitor<'b> {
     interval_s: u64,
     discovery_url: String,
     store_context: Arc<StoreContext>,
+    heartbeats: Arc<LoopHeartbeats>,
 }
 
 impl<'b> DiscoveryMonitor<'b> {
@@ -29,6 +31,7 @@ impl<'b> DiscoveryMonitor<'b> {
         interval_s: u64,
         discovery_url: String,
         store_context: Arc<StoreContext>,
+        heartbeats: Arc<LoopHeartbeats>,
     ) -> Self {
         Self {
             coordinator_wallet,
@@ -36,6 +39,7 @@ impl<'b> DiscoveryMonitor<'b> {
             interval_s,
             discovery_url,
             store_context,
+            heartbeats,
         }
     }
 
@@ -55,6 +59,7 @@ impl<'b> DiscoveryMonitor<'b> {
                     error!("Error syncing nodes from discovery service: {}", e);
                 }
             }
+            self.heartbeats.update_monitor();
         }
     }
     pub async fn fetch_nodes_from_discovery(&self) -> Result<Vec<DiscoveryNode>, Error> {
@@ -281,6 +286,7 @@ mod tests {
             10,
             "http://localhost:8080".to_string(),
             discovery_store_context,
+            Arc::new(LoopHeartbeats::new()),
         );
 
         let store_context_clone = store_context.clone();

--- a/orchestrator/src/main.rs
+++ b/orchestrator/src/main.rs
@@ -3,12 +3,14 @@ mod discovery;
 mod models;
 mod node;
 mod store;
+mod utils;
 use crate::api::server::start_server;
 use crate::discovery::monitor::DiscoveryMonitor;
 use crate::node::invite::NodeInviter;
 use crate::node::status_update::NodeStatusUpdater;
 use crate::store::core::RedisStore;
 use crate::store::core::StoreContext;
+use crate::utils::loop_heartbeats::LoopHeartbeats;
 use anyhow::Result;
 use clap::Parser;
 use log::debug;
@@ -16,10 +18,12 @@ use log::error;
 use log::LevelFilter;
 use shared::web3::contracts::core::builder::ContractBuilder;
 use shared::web3::wallet::Wallet;
+use std::sync::atomic::{AtomicI64, Ordering};
 use std::sync::Arc;
+use std::time::SystemTime;
+use std::time::UNIX_EPOCH;
 use tokio::task::JoinSet;
 use url::Url;
-
 #[derive(Parser)]
 struct Args {
     /// RPC URL
@@ -100,6 +104,8 @@ async fn main() -> Result<()> {
         .init();
     debug!("Log level: {}", log_level);
 
+    let heartbeats = Arc::new(LoopHeartbeats::new());
+
     let compute_pool_id = args.compute_pool_id;
     let domain_id = args.domain_id;
     let coordinator_key = args.coordinator_key;
@@ -130,6 +136,7 @@ async fn main() -> Result<()> {
     );
 
     let discovery_store_context = store_context.clone();
+    let discovery_heartbeats = heartbeats.clone();
     tasks.spawn(async move {
         let monitor = DiscoveryMonitor::new(
             wallet_clone.as_ref(),
@@ -137,6 +144,7 @@ async fn main() -> Result<()> {
             args.discovery_refresh_interval,
             args.discovery_url,
             discovery_store_context.clone(),
+            discovery_heartbeats.clone(),
         );
         monitor.run().await
     });
@@ -144,6 +152,7 @@ async fn main() -> Result<()> {
     let port = args.port;
 
     let inviter_store_context = store_context.clone();
+    let inviter_heartbeats = heartbeats.clone();
     tasks.spawn(async move {
         let inviter = NodeInviter::new(
             coordinator_wallet.as_ref(),
@@ -153,6 +162,7 @@ async fn main() -> Result<()> {
             Some(&args.port),
             args.url.as_deref(),
             inviter_store_context.clone(),
+            inviter_heartbeats.clone(),
         );
         inviter.run().await
     });
@@ -161,6 +171,7 @@ async fn main() -> Result<()> {
     // and calculating the status of the node.
     // It also ejects nodes when they are dead.
     let status_update_store_context = store_context.clone();
+    let status_update_heartbeats = heartbeats.clone();
     tasks.spawn(async move {
         let status_updater = NodeStatusUpdater::new(
             status_update_store_context.clone(),
@@ -169,13 +180,14 @@ async fn main() -> Result<()> {
             contracts.clone(),
             compute_pool_id,
             args.disable_ejection,
+            status_update_heartbeats.clone(),
         );
         status_updater.run().await
     });
 
     let server_store_context = store_context.clone();
     tokio::select! {
-        res = start_server("0.0.0.0", port, server_store_context.clone(), server_wallet, args.admin_api_key, args.s3_credentials, args.bucket_name) => {
+        res = start_server("0.0.0.0", port, server_store_context.clone(), server_wallet, args.admin_api_key, args.s3_credentials, args.bucket_name, heartbeats.clone()) => {
             if let Err(e) = res {
                 error!("Server error: {}", e);
             }

--- a/orchestrator/src/main.rs
+++ b/orchestrator/src/main.rs
@@ -18,10 +18,7 @@ use log::error;
 use log::LevelFilter;
 use shared::web3::contracts::core::builder::ContractBuilder;
 use shared::web3::wallet::Wallet;
-use std::sync::atomic::{AtomicI64, Ordering};
 use std::sync::Arc;
-use std::time::SystemTime;
-use std::time::UNIX_EPOCH;
 use tokio::task::JoinSet;
 use url::Url;
 #[derive(Parser)]

--- a/orchestrator/src/node/invite.rs
+++ b/orchestrator/src/node/invite.rs
@@ -1,6 +1,7 @@
 use crate::models::node::NodeStatus;
 use crate::models::node::OrchestratorNode;
 use crate::store::core::StoreContext;
+use crate::utils::loop_heartbeats::LoopHeartbeats;
 use alloy::primitives::utils::keccak256 as keccak;
 use alloy::primitives::U256;
 use alloy::signers::Signer;
@@ -23,6 +24,7 @@ pub struct NodeInviter<'a> {
     url: Option<&'a str>,
     store_context: Arc<StoreContext>,
     client: Client,
+    heartbeats: Arc<LoopHeartbeats>,
 }
 
 impl<'a> NodeInviter<'a> {
@@ -34,6 +36,7 @@ impl<'a> NodeInviter<'a> {
         port: Option<&'a u16>,
         url: Option<&'a str>,
         store_context: Arc<StoreContext>,
+        heartbeats: Arc<LoopHeartbeats>,
     ) -> Self {
         Self {
             wallet,
@@ -43,6 +46,7 @@ impl<'a> NodeInviter<'a> {
             port,
             url,
             store_context,
+            heartbeats,
             client: Client::builder()
                 .timeout(Duration::from_secs(15))
                 .build()
@@ -59,6 +63,7 @@ impl<'a> NodeInviter<'a> {
             if let Err(e) = self.process_uninvited_nodes().await {
                 error!("Error processing uninvited nodes: {}", e);
             }
+            self.heartbeats.update_inviter();
         }
     }
 

--- a/orchestrator/src/node/invite.rs
+++ b/orchestrator/src/node/invite.rs
@@ -28,6 +28,7 @@ pub struct NodeInviter<'a> {
 }
 
 impl<'a> NodeInviter<'a> {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         wallet: &'a Wallet,
         pool_id: u32,

--- a/orchestrator/src/node/status_update.rs
+++ b/orchestrator/src/node/status_update.rs
@@ -1,5 +1,6 @@
 use crate::models::node::{NodeStatus, OrchestratorNode};
 use crate::store::core::StoreContext;
+use crate::utils::loop_heartbeats::LoopHeartbeats;
 use anyhow::Ok;
 use log::{debug, error, info};
 use shared::web3::contracts::core::builder::Contracts;
@@ -15,6 +16,7 @@ pub struct NodeStatusUpdater {
     contracts: Arc<Contracts>,
     pool_id: u32,
     disable_ejection: bool,
+    heartbeats: Arc<LoopHeartbeats>,
 }
 
 impl NodeStatusUpdater {
@@ -25,6 +27,7 @@ impl NodeStatusUpdater {
         contracts: Arc<Contracts>,
         pool_id: u32,
         disable_ejection: bool,
+        heartbeats: Arc<LoopHeartbeats>,
     ) -> Self {
         Self {
             store_context,
@@ -33,6 +36,7 @@ impl NodeStatusUpdater {
             contracts,
             pool_id,
             disable_ejection,
+            heartbeats,
         }
     }
 
@@ -48,6 +52,7 @@ impl NodeStatusUpdater {
             if let Err(e) = self.sync_chain_with_nodes().await {
                 error!("Error syncing chain with nodes: {}", e);
             }
+            self.heartbeats.update_status_updater();
         }
     }
 
@@ -263,6 +268,7 @@ mod tests {
             Arc::new(contracts),
             0,
             false,
+            Arc::new(LoopHeartbeats::new()),
         );
         let node = OrchestratorNode {
             address: Address::from_str("0x0000000000000000000000000000000000000000").unwrap(),
@@ -334,6 +340,7 @@ mod tests {
             Arc::new(contracts),
             0,
             false,
+            Arc::new(LoopHeartbeats::new()),
         );
         tokio::spawn(async move {
             updater
@@ -377,6 +384,7 @@ mod tests {
             Arc::new(contracts),
             0,
             false,
+            Arc::new(LoopHeartbeats::new()),
         );
         tokio::spawn(async move {
             updater
@@ -430,6 +438,7 @@ mod tests {
             Arc::new(contracts),
             0,
             false,
+            Arc::new(LoopHeartbeats::new()),
         );
         tokio::spawn(async move {
             updater
@@ -486,6 +495,7 @@ mod tests {
             Arc::new(contracts),
             0,
             false,
+            Arc::new(LoopHeartbeats::new()),
         );
         tokio::spawn(async move {
             updater
@@ -551,6 +561,7 @@ mod tests {
             Arc::new(contracts),
             0,
             false,
+            Arc::new(LoopHeartbeats::new()),
         );
         tokio::spawn(async move {
             updater
@@ -615,6 +626,7 @@ mod tests {
             Arc::new(contracts),
             0,
             false,
+            Arc::new(LoopHeartbeats::new()),
         );
         tokio::spawn(async move {
             updater
@@ -676,6 +688,7 @@ mod tests {
             Arc::new(contracts),
             0,
             false,
+            Arc::new(LoopHeartbeats::new()),
         );
         tokio::spawn(async move {
             updater
@@ -731,6 +744,7 @@ mod tests {
             Arc::new(contracts),
             0,
             false,
+            Arc::new(LoopHeartbeats::new()),
         );
         tokio::spawn(async move {
             updater

--- a/orchestrator/src/utils/loop_heartbeats.rs
+++ b/orchestrator/src/utils/loop_heartbeats.rs
@@ -1,0 +1,103 @@
+use serde::Serialize;
+use std::sync::atomic::{AtomicI64, Ordering};
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+#[derive(Serialize)]
+pub struct HealthStatus {
+    pub healthy: bool,
+    pub inviter_last_run_seconds_ago: i64,
+    pub monitor_last_run_seconds_ago: i64,
+    pub status_updater_last_run_seconds_ago: i64,
+}
+
+pub struct LoopHeartbeats {
+    last_inviter_iteration: Arc<AtomicI64>,
+    last_monitor_iteration: Arc<AtomicI64>,
+    last_status_updater_iteration: Arc<AtomicI64>,
+}
+
+impl LoopHeartbeats {
+    pub fn new() -> Self {
+        Self {
+            last_inviter_iteration: Arc::new(AtomicI64::new(-1)),
+            last_monitor_iteration: Arc::new(AtomicI64::new(-1)),
+            last_status_updater_iteration: Arc::new(AtomicI64::new(-1)),
+        }
+    }
+
+    pub fn update_inviter(&self) {
+        self.last_inviter_iteration.store(
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_secs() as i64,
+            Ordering::SeqCst,
+        );
+    }
+
+    pub fn update_monitor(&self) {
+        self.last_monitor_iteration.store(
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_secs() as i64,
+            Ordering::SeqCst,
+        );
+    }
+
+    pub fn update_status_updater(&self) {
+        self.last_status_updater_iteration.store(
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_secs() as i64,
+            Ordering::SeqCst,
+        );
+    }
+
+    pub fn health_status(&self) -> HealthStatus {
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs() as i64;
+        let two_minutes = 120;
+
+        let inviter_last = self.last_inviter_iteration.load(Ordering::SeqCst);
+        let monitor_last = self.last_monitor_iteration.load(Ordering::SeqCst);
+        let status_updater_last = self.last_status_updater_iteration.load(Ordering::SeqCst);
+
+        // Calculate seconds ago for each operation
+        let inviter_seconds_ago = if inviter_last > 0 {
+            now - inviter_last
+        } else {
+            -1
+        };
+        let monitor_seconds_ago = if monitor_last > 0 {
+            now - monitor_last
+        } else {
+            -1
+        };
+        let status_updater_seconds_ago = if status_updater_last > 0 {
+            now - status_updater_last
+        } else {
+            -1
+        };
+
+        // All operations should have run at least once (not -1)
+        // and within the last 2 minutes
+        let healthy = inviter_last > 0
+            && inviter_seconds_ago < two_minutes
+            && monitor_last > 0
+            && monitor_seconds_ago < two_minutes
+            && status_updater_last > 0
+            && status_updater_seconds_ago < two_minutes;
+
+        HealthStatus {
+            healthy,
+            inviter_last_run_seconds_ago: inviter_seconds_ago,
+            monitor_last_run_seconds_ago: monitor_seconds_ago,
+            status_updater_last_run_seconds_ago: status_updater_seconds_ago,
+        }
+    }
+}

--- a/orchestrator/src/utils/mod.rs
+++ b/orchestrator/src/utils/mod.rs
@@ -1,2 +1,1 @@
 pub mod loop_heartbeats;
-use loop_heartbeats::*;

--- a/orchestrator/src/utils/mod.rs
+++ b/orchestrator/src/utils/mod.rs
@@ -1,0 +1,2 @@
+pub mod loop_heartbeats;
+use loop_heartbeats::*;


### PR DESCRIPTION
Ensure the /health endpoint on the orchestrator returns false if the loops do not operate anymore. 