### PR TITLE
Add compute node deregistration and stake reclamation 

### DIFF
--- a/shared/src/web3/contracts/implementations/prime_network_contract.rs
+++ b/shared/src/web3/contracts/implementations/prime_network_contract.rs
@@ -75,6 +75,29 @@ impl PrimeNetworkContract {
         Ok(add_node_tx)
     }
 
+    pub async fn remove_compute_node(
+        &self,
+        provider_address: Address,
+        node_address: Address,
+    ) -> Result<FixedBytes<32>, Box<dyn std::error::Error>> {
+        let remove_node_tx = self
+            .instance
+            .instance()
+            .function(
+                "removeComputeNode",
+                &[
+                    provider_address.into(),
+                    node_address.into(),                ],
+            )?
+            .send()
+            .await?
+            .watch()
+            .await?;
+
+        Ok(remove_node_tx)
+    }
+
+
     pub async fn validate_node(
         &self,
         provider_address: Address,
@@ -224,6 +247,19 @@ impl PrimeNetworkContract {
         }
 
         Ok(members_vec)
+    }
+
+    pub async fn reclaim_stake(&self, amount: U256) -> Result<FixedBytes<32>, Box<dyn std::error::Error>> {
+        let reclaim_tx = self
+            .instance
+            .instance()
+            .function("reclaimStake", &[amount.into()])?
+            .send()
+            .await?
+            .watch()
+            .await?;
+
+        Ok(reclaim_tx)
     }
 }
 

--- a/worker/src/cli/command.rs
+++ b/worker/src/cli/command.rs
@@ -130,6 +130,37 @@ pub enum Commands {
         #[arg(long)]
         private_key_node: Option<String>,
     },
+
+    /// Deregister worker from compute pool
+    Deregister {
+          /// Private key for the provider
+        #[arg(long)]
+        private_key_provider: Option<String>,
+
+        /// Private key for the node
+        #[arg(long)]
+        private_key_node: Option<String>,
+
+        /// RPC URL
+        #[arg(long, default_value = "http://localhost:8545")]
+        rpc_url: String,
+
+        /// State directory
+        #[arg(long)]
+        state_dir_overwrite: Option<String>,
+
+        /// Disable state storing
+        #[arg(long)]
+        disable_state_storing: bool,
+
+        /// Compute pool ID
+        #[arg(long)]
+        compute_pool_id: u64,
+
+        /// Auto accept transactions
+        #[arg(long, default_value = "false")]
+        auto_accept: bool,
+    },
 }
 
 pub async fn execute_command(
@@ -713,6 +744,154 @@ pub async fn execute_command(
                 [provider_signature.as_bytes(), node_signature.as_bytes()].concat();
 
             println!("\nSignature: {}", hex::encode(combined_signature));
+
+            Ok(())
+        }
+        Commands::Deregister {
+            state_dir_overwrite,
+            disable_state_storing,
+            private_key_provider,
+            private_key_node,
+            rpc_url,
+            compute_pool_id,
+            auto_accept
+        } => {
+            let private_key_provider = if let Some(key) = private_key_provider {
+                key.clone()
+            } else {
+                std::env::var("PRIVATE_KEY_PROVIDER").expect("PRIVATE_KEY_PROVIDER must be set")
+            };
+
+            let private_key_node = if let Some(key) = private_key_node {
+                key.clone()
+            } else {
+                std::env::var("PRIVATE_KEY_NODE").expect("PRIVATE_KEY_NODE must be set")
+            };
+
+            let provider_wallet_instance = Arc::new(
+                match Wallet::new(&private_key_provider, Url::parse(rpc_url).unwrap()) {
+                    Ok(wallet) => wallet,
+                    Err(err) => {
+                        Console::error(&format!("Failed to create wallet: {}", err));
+                        std::process::exit(1);
+                    }
+                },
+            );
+
+            let node_wallet_instance = Arc::new(
+                match Wallet::new(&private_key_node, Url::parse(rpc_url).unwrap()) {
+                    Ok(wallet) => wallet,
+                    Err(err) => {
+                        Console::error(&format!("❌ Failed to create wallet: {}", err));
+                        std::process::exit(1);
+                    }
+                },
+            );
+            let state = Arc::new(SystemState::new(
+                state_dir_overwrite.clone(),
+                *disable_state_storing,
+            ));
+            /*
+             Initialize dependencies - services, contracts, operations
+            */
+
+            
+            let contracts = Arc::new(
+                ContractBuilder::new(&provider_wallet_instance)
+                    .with_compute_registry()
+                    .with_ai_token()
+                    .with_prime_network()
+                    .with_compute_pool()
+                    .with_stake_manager()
+                    .build()
+                    .unwrap(),
+            );
+
+            let stake_manager = match contracts.stake_manager.as_ref() {
+                Some(stake_manager) => stake_manager,
+                None => {
+                    Console::error("❌ Stake manager not initialized");
+                    std::process::exit(1);
+                }
+            };
+
+
+            let compute_node_ops = ComputeNodeOperations::new(
+                &provider_wallet_instance,
+                &node_wallet_instance,
+                contracts.clone(),
+                state.clone(),
+            );
+
+            let provider_ops = ProviderOperations::new(
+                provider_wallet_instance.clone(),
+                contracts.clone(),
+                *auto_accept,
+            );
+
+            let compute_node_exists = match compute_node_ops.check_compute_node_exists().await {
+                Ok(exists) => exists,
+                Err(e) => {
+                    Console::error(&format!("❌ Failed to check if compute node exists: {}", e));
+                    std::process::exit(1);
+                }
+            };
+
+            let pool_id = U256::from(*compute_pool_id as u32);
+
+
+            if compute_node_exists {
+                // TODO: What if we have two nodes?
+                Console::success("Compute node is registered");
+                // check if node has a pool
+                // remove node from pool
+                match contracts
+                    .compute_pool
+                    .leave_compute_pool(pool_id,
+                        provider_wallet_instance
+                        .wallet
+                        .default_signer()
+                        .address(),
+                        node_wallet_instance
+                        .wallet
+                        .default_signer()
+                        .address(),
+                    )
+                    .await
+                {
+                    Ok(result) => {
+                        Console::success(&format!("Leave compute pool tx: {:?}", result));
+                    }
+                    Err(e) => {
+                        Console::error(&format!("❌ Failed to leave compute pool: {}", e));
+                        std::process::exit(1);
+                    }
+                }
+                match compute_node_ops.remove_compute_node().await {
+                    Ok(_removed_node) => {
+                        Console::success("Compute node removed");
+        
+                        match provider_ops
+                            .reclaim_stake(U256::from(0))
+                            .await
+                        {
+                            Ok(_) => {
+                                Console::success("Successfully reclaimed stake");
+                            }
+                            Err(e) => {
+                                Console::error(&format!("❌ Failed to reclaim stake: {}", e));
+                                std::process::exit(1);
+                            }
+                        }
+                    }
+                    Err(e) => {
+                        Console::error(&format!("❌ Failed to remove compute node: {}", e));
+                        std::process::exit(1);
+                    }
+                }
+            } else {
+                Console::success("Compute node is not registered");
+            }
 
             Ok(())
         }

--- a/worker/src/operations/compute_node.rs
+++ b/worker/src/operations/compute_node.rs
@@ -138,4 +138,26 @@ impl<'c> ComputeNodeOperations<'c> {
         Console::success(&format!("Add node tx: {:?}", add_node_tx));
         Ok(true)
     }
+
+    pub async fn remove_compute_node(
+        &self,
+    ) -> Result<bool, Box<dyn std::error::Error>> {
+        Console::title("🔄 Removing compute node");
+
+        if !self.check_compute_node_exists().await? {
+            return Ok(false);
+        }
+
+        Console::progress("Removing compute node");
+        let provider_address = self.provider_wallet.wallet.default_signer().address();
+        let node_address = self.node_wallet.wallet.default_signer().address();
+        // Create the signature bytes
+        let remove_node_tx = self
+            .contracts
+            .prime_network
+            .remove_compute_node(provider_address, node_address)
+            .await?;
+        Console::success(&format!("Remove node tx: {:?}", remove_node_tx));
+        Ok(true)
+    }
 }

--- a/worker/src/operations/provider.rs
+++ b/worker/src/operations/provider.rs
@@ -346,6 +346,24 @@ impl ProviderOperations {
         Console::success("Provider stake increased successfully");
         Ok(())
     }
+
+    pub async fn reclaim_stake(&self, amount: U256) -> Result<(), ProviderError> {
+        Console::progress("Reclaiming stake");
+        let reclaim_tx = match self.contracts.prime_network.reclaim_stake(amount).await {
+            Ok(tx) => tx,
+            Err(e) => {
+                println!("Failed to reclaim stake: {:?}", e);
+                return Err(ProviderError::Other);
+            }
+        };
+        Console::info(
+            "Stake reclaim transaction completed: ",
+            &format!("{:?}", reclaim_tx),
+        );
+        Console::success("Provider stake reclaimed successfully");
+        Ok(())
+    }
+
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
This PR introduces full support for deregistering compute nodes from the Prime Network and reclaiming associated stakes. Changes include:

- Added remove_compute_node method to PrimeNetworkContract

- Implemented reclaim_stake for providers

- Introduced new Deregister CLI command

- Extended ComputeNodeOperations and ProviderOperations with deregistration logic

**Motivation:**
I have been playing with the protocol and running some nodes for the last few weeks. 
It might be useful for a provider a command to remove a node from an active pool and reclaim the associated stake. It could for private credentials rotations, wanting to free some staked token for liquidity reasons etc.
I implemented the various changes required to implement the features and tested it locally.

Let me know if you guys think it could be useful, and if there is anything I can improve in the PR.
Best,
Marco 