### PR TITLE
Orchestrator: Keep old tasks in store

### DIFF
--- a/crates/orchestrator/src/api/routes/heartbeat.rs
+++ b/crates/orchestrator/src/api/routes/heartbeat.rs
@@ -34,7 +34,7 @@ async fn heartbeat(
         .store_context
         .metrics_store
         .store_metrics(heartbeat.metrics.clone(), node_address);
-    let current_task = app_state.store_context.task_store.get_task();
+    let current_task = app_state.store_context.task_store.get_current_task();
     let resp: HttpResponse = HeartbeatResponse { current_task }.into();
     resp
 }
@@ -116,7 +116,7 @@ mod tests {
             args: None,
             env_vars: None,
         };
-        app_state.store_context.task_store.set_task(task.into());
+        app_state.store_context.task_store.add_task(task.into());
 
         let req = test::TestRequest::post()
             .uri("/heartbeat")

--- a/crates/orchestrator/src/api/routes/task.rs
+++ b/crates/orchestrator/src/api/routes/task.rs
@@ -23,7 +23,6 @@ async fn get_all_tasks(app_state: Data<AppState>) -> HttpResponse {
 
 async fn create_task(task: web::Json<TaskRequest>, app_state: Data<AppState>) -> HttpResponse {
     let task = Task::from(task.into_inner());
-    println!("task: {:?}", task);
     let task_store = app_state.store_context.task_store.clone(); // Use TaskStore
     task_store.add_task(task);
     HttpResponse::Ok().json(json!({"success": true, "task": "updated_task"}))

--- a/crates/orchestrator/src/api/routes/task.rs
+++ b/crates/orchestrator/src/api/routes/task.rs
@@ -9,30 +9,38 @@ use shared::models::task::TaskRequest;
 
 async fn get_current_task(app_state: Data<AppState>) -> HttpResponse {
     let task_store = app_state.store_context.task_store.clone(); // Use TaskStore
-    match task_store.get_task() {
+    match task_store.get_current_task() {
         Some(task) => HttpResponse::Ok().json(json!({"success": true, "task": task})),
         None => HttpResponse::Ok().json(json!({"success": true, "task": null})),
     }
 }
 
-async fn update_task(task: web::Json<TaskRequest>, app_state: Data<AppState>) -> HttpResponse {
+async fn get_all_tasks(app_state: Data<AppState>) -> HttpResponse {
+    let task_store = app_state.store_context.task_store.clone();
+    let tasks = task_store.get_all_tasks();
+    HttpResponse::Ok().json(json!({"success": true, "tasks": tasks}))
+}
+
+async fn create_task(task: web::Json<TaskRequest>, app_state: Data<AppState>) -> HttpResponse {
     let task = Task::from(task.into_inner());
+    println!("task: {:?}", task);
     let task_store = app_state.store_context.task_store.clone(); // Use TaskStore
-    task_store.set_task(task);
+    task_store.add_task(task);
     HttpResponse::Ok().json(json!({"success": true, "task": "updated_task"}))
 }
 
-async fn delete_task(app_state: Data<AppState>) -> HttpResponse {
+async fn delete_current_task(app_state: Data<AppState>) -> HttpResponse {
     let task_store = app_state.store_context.task_store.clone(); // Use TaskStore
-    task_store.delete_task();
+    task_store.delete_current_task();
     HttpResponse::Ok().json(json!({"success": true, "task": "deleted_task"}))
 }
 
 pub fn tasks_routes() -> Scope {
     web::scope("/tasks")
-        .route("", get().to(get_current_task))
-        .route("", post().to(update_task))
-        .route("", delete().to(delete_task))
+        .route("/current", get().to(get_current_task))
+        .route("", get().to(get_all_tasks))
+        .route("", post().to(create_task))
+        .route("/current", delete().to(delete_current_task))
 }
 
 #[cfg(test)]
@@ -43,6 +51,8 @@ mod tests {
     use actix_web::test;
     use actix_web::App;
     use shared::models::task::Task;
+    use std::thread;
+    use std::time::Duration;
 
     #[actix_web::test]
     async fn test_get_current_task() {
@@ -50,11 +60,11 @@ mod tests {
         let app = test::init_service(
             App::new()
                 .app_data(app_state.clone())
-                .route("/tasks", get().to(get_current_task)),
+                .route("/tasks/current", get().to(get_current_task)),
         )
         .await;
 
-        let req = test::TestRequest::get().uri("/tasks").to_request();
+        let req = test::TestRequest::get().uri("/tasks/current").to_request();
         let resp = test::call_service(&app, req).await;
         assert_eq!(resp.status(), StatusCode::OK);
     }
@@ -65,7 +75,7 @@ mod tests {
         let app = test::init_service(
             App::new()
                 .app_data(app_state.clone())
-                .route("/tasks", post().to(update_task)),
+                .route("/tasks", post().to(create_task)),
         )
         .await;
 
@@ -84,7 +94,7 @@ mod tests {
         assert_eq!(resp.status(), StatusCode::OK);
 
         let task_store = app_state.store_context.task_store.clone(); // Use TaskStore
-        let task: Task = task_store.get_task().unwrap();
+        let task: Task = task_store.get_current_task().unwrap();
         assert_eq!(task.image, "test");
     }
 
@@ -94,11 +104,11 @@ mod tests {
         let app = test::init_service(
             App::new()
                 .app_data(app_state.clone())
-                .route("/tasks", get().to(get_current_task)),
+                .route("/tasks/current", get().to(get_current_task)),
         )
         .await;
 
-        let req = test::TestRequest::get().uri("/tasks").to_request();
+        let req = test::TestRequest::get().uri("/tasks/current").to_request();
         let resp = test::call_service(&app, req).await;
         assert_eq!(resp.status(), StatusCode::OK);
         let body = test::read_body(resp).await;
@@ -121,16 +131,16 @@ mod tests {
         .into();
 
         let task_store = app_state.store_context.task_store.clone(); // Use TaskStore
-        task_store.set_task(task);
+        task_store.add_task(task);
 
         let app = test::init_service(
             App::new()
                 .app_data(app_state.clone())
-                .route("/tasks", get().to(get_current_task)),
+                .route("/tasks/current", get().to(get_current_task)),
         )
         .await;
 
-        let req = test::TestRequest::get().uri("/tasks").to_request();
+        let req = test::TestRequest::get().uri("/tasks/current").to_request();
         let resp = test::call_service(&app, req).await;
         assert_eq!(resp.status(), StatusCode::OK);
 
@@ -149,7 +159,7 @@ mod tests {
         let app = test::init_service(
             App::new()
                 .app_data(app_state.clone())
-                .route("/tasks", delete().to(delete_task)),
+                .route("/tasks/current", delete().to(delete_current_task)),
         )
         .await;
 
@@ -163,13 +173,108 @@ mod tests {
         .into();
 
         let task_store = app_state.store_context.task_store.clone(); // Use TaskStore
-        task_store.set_task(task);
+        task_store.add_task(task);
 
-        let req = test::TestRequest::delete().uri("/tasks").to_request();
+        let req = test::TestRequest::delete()
+            .uri("/tasks/current")
+            .to_request();
         let resp = test::call_service(&app, req).await;
         assert_eq!(resp.status(), StatusCode::OK);
 
-        let task_value = task_store.get_task(); // Use TaskStore
+        let task_value = task_store.get_current_task(); // Use TaskStore
         assert!(task_value.is_none());
+    }
+
+    #[actix_web::test]
+    async fn test_multiple_tasks_sorting() {
+        let app_state = create_test_app_state().await;
+        let app = test::init_service(
+            App::new()
+                .app_data(app_state.clone())
+                .route("/tasks", get().to(get_all_tasks))
+                .route("/tasks/current", get().to(get_current_task)),
+        )
+        .await;
+
+        let task_store = app_state.store_context.task_store.clone();
+
+        // Create first task
+        let task1: Task = TaskRequest {
+            image: "test1".to_string(),
+            name: "test1".to_string(),
+            command: None,
+            args: None,
+            env_vars: None,
+        }
+        .into();
+        task_store.add_task(task1.clone());
+
+        // Wait briefly to ensure different timestamps
+        thread::sleep(Duration::from_millis(10));
+
+        // Create second task
+        let task2: Task = TaskRequest {
+            image: "test2".to_string(),
+            name: "test2".to_string(),
+            command: None,
+            args: None,
+            env_vars: None,
+        }
+        .into();
+        task_store.add_task(task2.clone());
+
+        // Test get all tasks - should be sorted by created_at descending
+        let req = test::TestRequest::get().uri("/tasks").to_request();
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let body = test::read_body(resp).await;
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        let tasks = json["tasks"].as_array().unwrap();
+
+        assert_eq!(tasks.len(), 2);
+        assert_eq!(tasks[0]["image"], "test2");
+        assert_eq!(tasks[1]["image"], "test1");
+
+        // Test get current task - should return newest task
+        let req = test::TestRequest::get().uri("/tasks/current").to_request();
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let body = test::read_body(resp).await;
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["task"]["image"], "test2");
+    }
+
+    #[actix_web::test]
+    async fn test_task_ordering_with_multiple_additions() {
+        let app_state = create_test_app_state().await;
+        let task_store = app_state.store_context.task_store.clone();
+
+        // Add tasks in sequence with delays
+        for i in 1..=3 {
+            let task: Task = TaskRequest {
+                image: format!("test{}", i),
+                name: format!("test{}", i),
+                command: None,
+                args: None,
+                env_vars: None,
+            }
+            .into();
+            task_store.add_task(task);
+            thread::sleep(Duration::from_millis(10));
+        }
+
+        let tasks = task_store.get_all_tasks();
+
+        // Verify tasks are ordered by created_at descending
+        assert_eq!(tasks.len(), 3);
+        assert_eq!(tasks[0].image, "test3");
+        assert_eq!(tasks[1].image, "test2");
+        assert_eq!(tasks[2].image, "test1");
+
+        // Verify current task is the newest one
+        let current = task_store.get_current_task().unwrap();
+        assert_eq!(current.image, "test3");
     }
 }

--- a/crates/orchestrator/src/store/domains/task_store.rs
+++ b/crates/orchestrator/src/store/domains/task_store.rs
@@ -3,7 +3,9 @@ use redis::Commands;
 use shared::models::task::Task;
 use std::sync::Arc;
 
-const TASK_KEY: &str = "orchestrator:task:current";
+const TASK_KEY_PREFIX: &str = "orchestrator:task:";
+const TASK_LIST_KEY: &str = "orchestrator:tasks";
+const CURRENT_TASK_KEY: &str = "orchestrator:task:current";
 
 pub struct TaskStore {
     redis: Arc<RedisStore>,
@@ -14,23 +16,52 @@ impl TaskStore {
         Self { redis }
     }
 
-    pub fn get_task(&self) -> Option<Task> {
+    pub fn get_current_task(&self) -> Option<Task> {
         let mut con = self.redis.client.get_connection().unwrap();
-        let has_key: bool = con.exists(TASK_KEY).unwrap();
+        let has_key: bool = con.exists(CURRENT_TASK_KEY).unwrap();
         if !has_key {
             return None;
         }
-        let task: Task = con.get(TASK_KEY).unwrap();
+        let task: Task = con.get(CURRENT_TASK_KEY).unwrap();
         Some(task)
     }
 
-    pub fn set_task(&self, task: Task) {
+    pub fn add_task(&self, task: Task) {
         let mut con = self.redis.client.get_connection().unwrap();
-        let _: () = con.set(TASK_KEY, task).unwrap();
+
+        // Store the task with its ID as key
+        let task_key = format!("{}{}", TASK_KEY_PREFIX, task.id);
+        let _: () = con.set(&task_key, task.clone()).unwrap();
+
+        // Add task ID to list of all tasks
+        let _: () = con.rpush(TASK_LIST_KEY, task.id.to_string()).unwrap();
+
+        // Set as current task
+        let _: () = con.set(CURRENT_TASK_KEY, task).unwrap();
     }
 
-    pub fn delete_task(&self) {
+    pub fn get_all_tasks(&self) -> Vec<Task> {
         let mut con = self.redis.client.get_connection().unwrap();
-        let _: () = con.del(TASK_KEY).unwrap();
+
+        // Get all task IDs
+        let task_ids: Vec<String> = con.lrange(TASK_LIST_KEY, 0, -1).unwrap();
+
+        // Get each task by ID and collect into vector
+        let mut tasks: Vec<Task> = task_ids
+            .iter()
+            .map(|id| {
+                let task_key = format!("{}{}", TASK_KEY_PREFIX, id);
+                con.get(&task_key).unwrap()
+            })
+            .collect();
+
+        tasks.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+
+        tasks
+    }
+
+    pub fn delete_current_task(&self) {
+        let mut con = self.redis.client.get_connection().unwrap();
+        let _: () = con.del(CURRENT_TASK_KEY).unwrap();
     }
 }

--- a/crates/shared/src/models/task.rs
+++ b/crates/shared/src/models/task.rs
@@ -67,7 +67,7 @@ pub struct Task {
     #[serde(default)]
     pub created_at: i64,
     #[serde(default)]
-    pub updated_at: Option<u64>
+    pub updated_at: Option<u64>,
 }
 
 impl From<TaskRequest> for Task {
@@ -81,7 +81,7 @@ impl From<TaskRequest> for Task {
             env_vars: request.env_vars,
             state: TaskState::PENDING,
             created_at: Utc::now().timestamp_millis(),
-            updated_at: None 
+            updated_at: None,
         }
     }
 }

--- a/crates/shared/src/models/task.rs
+++ b/crates/shared/src/models/task.rs
@@ -1,3 +1,4 @@
+use chrono::Utc;
 use redis::{ErrorKind, FromRedisValue, RedisError, RedisResult, RedisWrite, ToRedisArgs, Value};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
@@ -54,7 +55,6 @@ pub struct TaskRequest {
     pub command: Option<String>,
     pub args: Option<Vec<String>>,
 }
-
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Task {
     pub id: Uuid,
@@ -64,6 +64,10 @@ pub struct Task {
     pub command: Option<String>,
     pub args: Option<Vec<String>>,
     pub state: TaskState,
+    #[serde(default)]
+    pub created_at: i64,
+    #[serde(default)]
+    pub updated_at: Option<u64>
 }
 
 impl From<TaskRequest> for Task {
@@ -76,6 +80,8 @@ impl From<TaskRequest> for Task {
             args: request.args,
             env_vars: request.env_vars,
             state: TaskState::PENDING,
+            created_at: Utc::now().timestamp_millis(),
+            updated_at: None 
         }
     }
 }

--- a/crates/worker/src/docker/service.rs
+++ b/crates/worker/src/docker/service.rs
@@ -362,6 +362,8 @@ mod tests {
             command: Some("sleep".to_string()),
             args: Some(vec!["100".to_string()]),
             state: TaskState::PENDING,
+            created_at: Utc::now().timestamp_millis(),
+            updated_at: None,
         };
         let task_clone = task.clone();
         let state_clone = docker_service.state.clone();
@@ -410,6 +412,8 @@ mod tests {
             command: Some("invalid_command".to_string()),
             args: None,
             state: TaskState::PENDING,
+            created_at: Utc::now().timestamp_millis(),
+            updated_at: None,
         };
 
         let task_clone = task.clone();


### PR DESCRIPTION
keep all tasks in orchestrator store, add get_all functionality, change route from /tasks to /tasks/current to get the running task