### PR TITLE
introduce server modes to improve scalability of svc

### DIFF
--- a/crates/orchestrator/Dockerfile
+++ b/crates/orchestrator/Dockerfile
@@ -22,6 +22,7 @@ ENV BUCKET_NAME=""
 ENV LOG_LEVEL=""
 ENV HOURLY_S3_UPLOAD_LIMIT="2"
 ENV WEBHOOK_URLS=""
+ENV MODE="full"
 
 RUN echo '#!/bin/sh\n\
 exec /usr/local/bin/orchestrator \
@@ -36,6 +37,7 @@ $([ ! -z "$HOST" ] && echo "--host $HOST") \
 --redis-store-url "$REDIS_STORE_URL" \
 --discovery-url "$DISCOVERY_URL" \
 --admin-api-key "$ADMIN_API_KEY" \
+--mode "$MODE" \
 $([ "$DISABLE_EJECTION" = "true" ] && echo "--disable-ejection") \
 $([ ! -z "$S3_CREDENTIALS" ] && echo "--s3-credentials $S3_CREDENTIALS") \
 $([ ! -z "$BUCKET_NAME" ] && echo "--bucket-name $BUCKET_NAME") \

--- a/crates/orchestrator/src/api/tests/helper.rs
+++ b/crates/orchestrator/src/api/tests/helper.rs
@@ -17,7 +17,7 @@ use url::Url;
 
 #[cfg(test)]
 pub async fn create_test_app_state() -> Data<AppState> {
-    use crate::utils::loop_heartbeats::LoopHeartbeats;
+    use crate::{utils::loop_heartbeats::LoopHeartbeats, ServerMode};
 
     let store = Arc::new(RedisStore::new_test());
     let mut con = store
@@ -33,6 +33,7 @@ pub async fn create_test_app_state() -> Data<AppState> {
         .expect("Redis should be flushed");
 
     let store_context = Arc::new(StoreContext::new(store.clone()));
+    let mode = ServerMode::Full;
     Data::new(AppState {
         store_context: store_context.clone(),
         contracts: None,
@@ -46,7 +47,7 @@ pub async fn create_test_app_state() -> Data<AppState> {
         ),
         s3_credentials: None,
         bucket_name: None,
-        heartbeats: Arc::new(LoopHeartbeats::new()),
+        heartbeats: Arc::new(LoopHeartbeats::new(&mode)),
         hourly_upload_limit: 12,
         redis_store: store.clone(),
     })

--- a/crates/orchestrator/src/discovery/monitor.rs
+++ b/crates/orchestrator/src/discovery/monitor.rs
@@ -231,6 +231,7 @@ mod tests {
     use super::*;
     use crate::models::node::NodeStatus;
     use crate::store::core::{RedisStore, StoreContext};
+    use crate::ServerMode;
 
     #[tokio::test]
     async fn test_sync_single_node_with_discovery() {
@@ -280,13 +281,15 @@ mod tests {
         )
         .unwrap();
 
+        let mode = ServerMode::Full;
+
         let discovery_monitor = DiscoveryMonitor::new(
             &fake_wallet,
             1,
             10,
             "http://localhost:8080".to_string(),
             discovery_store_context,
-            Arc::new(LoopHeartbeats::new()),
+            Arc::new(LoopHeartbeats::new(&mode)),
         );
 
         let store_context_clone = store_context.clone();

--- a/crates/orchestrator/src/node/status_update.rs
+++ b/crates/orchestrator/src/node/status_update.rs
@@ -319,6 +319,7 @@ mod tests {
     use crate::api::tests::helper::setup_contract;
     use crate::models::node::NodeStatus;
     use crate::models::node::OrchestratorNode;
+    use crate::ServerMode;
     use alloy::primitives::Address;
     use shared::models::heartbeat::HeartbeatRequest;
     use std::str::FromStr;
@@ -329,7 +330,7 @@ mod tests {
     async fn test_node_status_updater_runs() {
         let app_state = create_test_app_state().await;
         let contracts = setup_contract();
-
+        let mode = ServerMode::Full;
         let updater = NodeStatusUpdater::new(
             app_state.store_context.clone(),
             5,
@@ -337,7 +338,7 @@ mod tests {
             Arc::new(contracts),
             0,
             false,
-            Arc::new(LoopHeartbeats::new()),
+            Arc::new(LoopHeartbeats::new(&mode)),
             vec![],
         );
         let node = OrchestratorNode {
@@ -404,6 +405,7 @@ mod tests {
         };
 
         let _: () = app_state.store_context.node_store.add_node(node.clone());
+        let mode = ServerMode::Full;
         let updater = NodeStatusUpdater::new(
             app_state.store_context.clone(),
             5,
@@ -411,7 +413,7 @@ mod tests {
             Arc::new(contracts),
             0,
             false,
-            Arc::new(LoopHeartbeats::new()),
+            Arc::new(LoopHeartbeats::new(&mode)),
             vec![],
         );
         tokio::spawn(async move {
@@ -449,6 +451,7 @@ mod tests {
         };
 
         let _: () = app_state.store_context.node_store.add_node(node.clone());
+        let mode = ServerMode::Full;
         let updater = NodeStatusUpdater::new(
             app_state.store_context.clone(),
             5,
@@ -456,7 +459,7 @@ mod tests {
             Arc::new(contracts),
             0,
             false,
-            Arc::new(LoopHeartbeats::new()),
+            Arc::new(LoopHeartbeats::new(&mode)),
             vec![],
         );
         tokio::spawn(async move {
@@ -504,6 +507,7 @@ mod tests {
             .heartbeat_store
             .set_unhealthy_counter(&node.address, 2);
 
+        let mode = ServerMode::Full;
         let updater = NodeStatusUpdater::new(
             app_state.store_context.clone(),
             5,
@@ -511,7 +515,7 @@ mod tests {
             Arc::new(contracts),
             0,
             false,
-            Arc::new(LoopHeartbeats::new()),
+            Arc::new(LoopHeartbeats::new(&mode)),
             vec![],
         );
         tokio::spawn(async move {
@@ -563,6 +567,7 @@ mod tests {
         let _: () = app_state.store_context.heartbeat_store.beat(&heartbeat);
         let _: () = app_state.store_context.node_store.add_node(node.clone());
 
+        let mode = ServerMode::Full;
         let updater = NodeStatusUpdater::new(
             app_state.store_context.clone(),
             5,
@@ -570,7 +575,7 @@ mod tests {
             Arc::new(contracts),
             0,
             false,
-            Arc::new(LoopHeartbeats::new()),
+            Arc::new(LoopHeartbeats::new(&mode)),
             vec![],
         );
         tokio::spawn(async move {
@@ -630,6 +635,7 @@ mod tests {
 
         let _: () = app_state.store_context.node_store.add_node(node2.clone());
 
+        let mode = ServerMode::Full;
         let updater = NodeStatusUpdater::new(
             app_state.store_context.clone(),
             5,
@@ -637,7 +643,7 @@ mod tests {
             Arc::new(contracts),
             0,
             false,
-            Arc::new(LoopHeartbeats::new()),
+            Arc::new(LoopHeartbeats::new(&mode)),
             vec![],
         );
         tokio::spawn(async move {
@@ -696,6 +702,7 @@ mod tests {
             .heartbeat_store
             .set_unhealthy_counter(&node.address, 2);
 
+        let mode = ServerMode::Full;
         let updater = NodeStatusUpdater::new(
             app_state.store_context.clone(),
             5,
@@ -703,7 +710,7 @@ mod tests {
             Arc::new(contracts),
             0,
             false,
-            Arc::new(LoopHeartbeats::new()),
+            Arc::new(LoopHeartbeats::new(&mode)),
             vec![],
         );
         tokio::spawn(async move {
@@ -759,6 +766,7 @@ mod tests {
         };
 
         let _: () = app_state.store_context.node_store.add_node(node.clone());
+        let mode = ServerMode::Full;
         let updater = NodeStatusUpdater::new(
             app_state.store_context.clone(),
             5,
@@ -766,7 +774,7 @@ mod tests {
             Arc::new(contracts),
             0,
             false,
-            Arc::new(LoopHeartbeats::new()),
+            Arc::new(LoopHeartbeats::new(&mode)),
             vec![],
         );
         tokio::spawn(async move {
@@ -816,6 +824,7 @@ mod tests {
         assert_eq!(counter, 0);
 
         let _: () = app_state.store_context.node_store.add_node(node.clone());
+        let mode = ServerMode::Full;
         let updater = NodeStatusUpdater::new(
             app_state.store_context.clone(),
             5,
@@ -823,7 +832,7 @@ mod tests {
             Arc::new(contracts),
             0,
             false,
-            Arc::new(LoopHeartbeats::new()),
+            Arc::new(LoopHeartbeats::new(&mode)),
             vec![],
         );
         tokio::spawn(async move {

--- a/deployment/k8s/orchestrator-chart/templates/orchestrator-deployment.yaml
+++ b/deployment/k8s/orchestrator-chart/templates/orchestrator-deployment.yaml
@@ -1,30 +1,8 @@
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: {{ include "orchestrator.fullname" . }}
-  namespace: {{ .Values.namespace }}
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      app: {{ include "orchestrator.fullname" . }}
-  template:
-    metadata:
-      labels:
-        app: {{ include "orchestrator.fullname" . }}
-    spec:
-      containers:
-        - name: orchestrator
-          image: {{ .Values.image }}
+{{- define "orchestrator.container" }}
+          image: {{ .root.Values.image }}
+          {{- if .api }}
           ports:
             - containerPort: 8090
-          resources:
-            requests:
-              memory: "256Mi"
-              cpu: "500m"
-            limits:
-              memory: "512Mi"
-              cpu: "2000m"
           readinessProbe:
             httpGet:
               path: /health
@@ -37,45 +15,92 @@ spec:
               port: 8090
             initialDelaySeconds: 15
             periodSeconds: 20
+          {{- end }}
+          resources:
+            requests:
+              memory: "256Mi"
+              cpu: "500m"
+            limits:
+              memory: "512Mi"
+              cpu: "2000m"
           env:
             - name: URL
-              value: {{ .Values.url }}
+              value: {{ .root.Values.url }}
             - name: RPC_URL
-              value: {{ .Values.env.RPC_URL }}
+              value: {{ .root.Values.env.RPC_URL }}
             - name: MODE
-              value: {{ .Values.env.MODE }}
+              value: {{ .mode }}
             - name: REDIS_STORE_URL
-              value: "redis://{{ include "orchestrator.redisName" . }}:6379"
+              value: "redis://{{ include "orchestrator.redisName" .root }}:6379"
             - name: DISCOVERY_URL
-              value: {{ .Values.env.DISCOVERY_URL }}
+              value: {{ .root.Values.env.DISCOVERY_URL }}
             - name: COORDINATOR_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "orchestrator.secretName" . }}
+                  name: {{ include "orchestrator.secretName" .root }}
                   key: coordinatorKey
             - name: ADMIN_API_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "orchestrator.secretName" . }}
+                  name: {{ include "orchestrator.secretName" .root }}
                   key: adminApiKey
             - name: S3_CREDENTIALS
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "orchestrator.secretName" . }}
+                  name: {{ include "orchestrator.secretName" .root }}
                   key: s3Credentials
             - name: COMPUTE_POOL_ID
-              value: "{{ .Values.computePoolId }}"
+              value: "{{ .root.Values.computePoolId }}"
             - name: DOMAIN_ID
-              value: "{{ .Values.domainId }}"
+              value: "{{ .root.Values.domainId }}"
             - name: DISCOVERY_REFRESH_INTERVAL
-              value: "{{ .Values.env.DISCOVERY_REFRESH_INTERVAL }}"
+              value: "{{ .root.Values.env.DISCOVERY_REFRESH_INTERVAL }}"
             - name: BUCKET_NAME
-              value: "{{ .Values.env.BUCKET_NAME }}"
+              value: "{{ .root.Values.env.BUCKET_NAME }}"
             - name: LOG_LEVEL
-              value: "{{ .Values.env.LOG_LEVEL }}"
+              value: "{{ .root.Values.env.LOG_LEVEL }}"
             - name: HOURLY_S3_UPLOAD_LIMIT
-              value: "{{ .Values.env.HOURLY_S3_UPLOAD_LIMIT }}"
-            {{- if .Values.env.WEBHOOK_URLS }}
+              value: "{{ .root.Values.env.HOURLY_S3_UPLOAD_LIMIT }}"
+            {{- if .root.Values.env.WEBHOOK_URLS }}
             - name: WEBHOOK_URLS
-              value: "{{ .Values.env.WEBHOOK_URLS }}"
+              value: "{{ .root.Values.env.WEBHOOK_URLS }}"
             {{- end }}
+{{- end }}
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "orchestrator.fullname" . }}-api
+  namespace: {{ .Values.namespace }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ include "orchestrator.fullname" . }}-api
+  template:
+    metadata:
+      labels:
+        app: {{ include "orchestrator.fullname" . }}-api
+    spec:
+      containers:
+        - name: orchestrator-api
+          {{- include "orchestrator.container" (dict "root" . "mode" "api" "api" true) | nindent 10 }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "orchestrator.fullname" . }}-processor
+  namespace: {{ .Values.namespace }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ include "orchestrator.fullname" . }}-processor
+  template:
+    metadata:
+      labels:
+        app: {{ include "orchestrator.fullname" . }}-processor
+    spec:
+      containers:
+        - name: orchestrator-processor
+          {{- include "orchestrator.container" (dict "root" . "mode" "processor" "api" false) | nindent 10 }}

--- a/deployment/k8s/orchestrator-chart/templates/orchestrator-deployment.yaml
+++ b/deployment/k8s/orchestrator-chart/templates/orchestrator-deployment.yaml
@@ -42,6 +42,8 @@ spec:
               value: {{ .Values.url }}
             - name: RPC_URL
               value: {{ .Values.env.RPC_URL }}
+            - name: MODE
+              value: {{ .Values.env.MODE }}
             - name: REDIS_STORE_URL
               value: "redis://{{ include "orchestrator.redisName" . }}:6379"
             - name: DISCOVERY_URL

--- a/deployment/k8s/orchestrator-chart/templates/orchestrator-deployment.yaml
+++ b/deployment/k8s/orchestrator-chart/templates/orchestrator-deployment.yaml
@@ -1,70 +1,71 @@
 {{- define "orchestrator.container" }}
-          image: {{ .root.Values.image }}
-          {{- if .api }}
-          ports:
-            - containerPort: 8090
-          readinessProbe:
-            httpGet:
-              path: /health
-              port: 8090
-            initialDelaySeconds: 5
-            periodSeconds: 10
-          livenessProbe:
-            httpGet:
-              path: /health
-              port: 8090
-            initialDelaySeconds: 15
-            periodSeconds: 20
-          {{- end }}
-          resources:
-            requests:
-              memory: "256Mi"
-              cpu: "500m"
-            limits:
-              memory: "512Mi"
-              cpu: "2000m"
-          env:
-            - name: URL
-              value: {{ .root.Values.url }}
-            - name: RPC_URL
-              value: {{ .root.Values.env.RPC_URL }}
-            - name: MODE
-              value: {{ .mode }}
-            - name: REDIS_STORE_URL
-              value: "redis://{{ include "orchestrator.redisName" .root }}:6379"
-            - name: DISCOVERY_URL
-              value: {{ .root.Values.env.DISCOVERY_URL }}
-            - name: COORDINATOR_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "orchestrator.secretName" .root }}
-                  key: coordinatorKey
-            - name: ADMIN_API_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "orchestrator.secretName" .root }}
-                  key: adminApiKey
-            - name: S3_CREDENTIALS
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "orchestrator.secretName" .root }}
-                  key: s3Credentials
-            - name: COMPUTE_POOL_ID
-              value: "{{ .root.Values.computePoolId }}"
-            - name: DOMAIN_ID
-              value: "{{ .root.Values.domainId }}"
-            - name: DISCOVERY_REFRESH_INTERVAL
-              value: "{{ .root.Values.env.DISCOVERY_REFRESH_INTERVAL }}"
-            - name: BUCKET_NAME
-              value: "{{ .root.Values.env.BUCKET_NAME }}"
-            - name: LOG_LEVEL
-              value: "{{ .root.Values.env.LOG_LEVEL }}"
-            - name: HOURLY_S3_UPLOAD_LIMIT
-              value: "{{ .root.Values.env.HOURLY_S3_UPLOAD_LIMIT }}"
-            {{- if .root.Values.env.WEBHOOK_URLS }}
-            - name: WEBHOOK_URLS
-              value: "{{ .root.Values.env.WEBHOOK_URLS }}"
-            {{- end }}
+- name: {{ .root.Values.name | default "orchestrator" }}
+  image: {{ .root.Values.image }}
+  {{- if .api }}
+  ports:
+    - containerPort: 8090
+  readinessProbe:
+    httpGet:
+      path: /health
+      port: 8090
+    initialDelaySeconds: 5
+    periodSeconds: 10
+  livenessProbe:
+    httpGet:
+      path: /health
+      port: 8090
+    initialDelaySeconds: 15
+    periodSeconds: 20
+  {{- end }}
+  resources:
+    requests:
+      memory: "256Mi"
+      cpu: "500m"
+    limits:
+      memory: "512Mi"
+      cpu: "2000m"
+  env:
+    - name: URL
+      value: {{ .root.Values.url }}
+    - name: RPC_URL
+      value: {{ .root.Values.env.RPC_URL }}
+    - name: MODE
+      value: {{ .mode }}
+    - name: REDIS_STORE_URL
+      value: "redis://{{ include "orchestrator.redisName" .root }}:6379"
+    - name: DISCOVERY_URL
+      value: {{ .root.Values.env.DISCOVERY_URL }}
+    - name: COORDINATOR_KEY
+      valueFrom:
+        secretKeyRef:
+          name: {{ include "orchestrator.secretName" .root }}
+          key: coordinatorKey
+    - name: ADMIN_API_KEY
+      valueFrom:
+        secretKeyRef:
+          name: {{ include "orchestrator.secretName" .root }}
+          key: adminApiKey
+    - name: S3_CREDENTIALS
+      valueFrom:
+        secretKeyRef:
+          name: {{ include "orchestrator.secretName" .root }}
+          key: s3Credentials
+    - name: COMPUTE_POOL_ID
+      value: "{{ .root.Values.computePoolId }}"
+    - name: DOMAIN_ID
+      value: "{{ .root.Values.domainId }}"
+    - name: DISCOVERY_REFRESH_INTERVAL
+      value: "{{ .root.Values.env.DISCOVERY_REFRESH_INTERVAL }}"
+    - name: BUCKET_NAME
+      value: "{{ .root.Values.env.BUCKET_NAME }}"
+    - name: LOG_LEVEL
+      value: "{{ .root.Values.env.LOG_LEVEL }}"
+    - name: HOURLY_S3_UPLOAD_LIMIT
+      value: "{{ .root.Values.env.HOURLY_S3_UPLOAD_LIMIT }}"
+    {{- if .root.Values.env.WEBHOOK_URLS }}
+    - name: WEBHOOK_URLS
+      value: "{{ .root.Values.env.WEBHOOK_URLS }}"
+    {{- end }}
 {{- end }}
 
 apiVersion: apps/v1
@@ -83,8 +84,7 @@ spec:
         app: {{ include "orchestrator.fullname" . }}-api
     spec:
       containers:
-        - name: orchestrator-api
-          {{- include "orchestrator.container" (dict "root" . "mode" "api" "api" true) | nindent 10 }}
+        {{- include "orchestrator.container" (dict "root" . "mode" "api" "api" true) | nindent 8 }}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -102,5 +102,4 @@ spec:
         app: {{ include "orchestrator.fullname" . }}-processor
     spec:
       containers:
-        - name: orchestrator-processor
-          {{- include "orchestrator.container" (dict "root" . "mode" "processor" "api" false) | nindent 10 }}
+        {{- include "orchestrator.container" (dict "root" . "mode" "processor" "api" false) | nindent 8 }}

--- a/deployment/k8s/orchestrator-chart/values.example.yaml
+++ b/deployment/k8s/orchestrator-chart/values.example.yaml
@@ -10,7 +10,6 @@ env:
   DISCOVERY_REFRESH_INTERVAL: "60"
   BUCKET_NAME: "your-bucket-name"
   LOG_LEVEL: "info"
-  MODE: "full"
 
 secrets:
   coordinatorKey: "your-coordinator-private-key"

--- a/deployment/k8s/orchestrator-chart/values.example.yaml
+++ b/deployment/k8s/orchestrator-chart/values.example.yaml
@@ -10,6 +10,7 @@ env:
   DISCOVERY_REFRESH_INTERVAL: "60"
   BUCKET_NAME: "your-bucket-name"
   LOG_LEVEL: "info"
+  MODE: "full"
 
 secrets:
   coordinatorKey: "your-coordinator-private-key"


### PR DESCRIPTION
We introduce new server modes to enable / disable the processing of nodes on the orchestrator. 
This way we can have autoscaling around the API while having one processor. K8s handles the rest.  
fixes #19 