### PR TITLE
feat(orchestrator): add auto-restart for completed tasks

### DIFF
--- a/crates/orchestrator/src/api/routes/heartbeat.rs
+++ b/crates/orchestrator/src/api/routes/heartbeat.rs
@@ -8,6 +8,7 @@ use serde_json::json;
 use shared::models::{
     api::ApiResponse,
     heartbeat::{HeartbeatRequest, HeartbeatResponse},
+    task::{Task, TaskRequest},
 };
 use std::str::FromStr;
 
@@ -29,8 +30,8 @@ async fn heartbeat(
 
     app_state.store_context.node_store.update_node_task(
         node_address,
-        task_info.task_id,
-        task_info.task_state,
+        task_info.task_id.clone(),
+        task_info.task_state.clone(),
     );
 
     if let Some(p2p_id) = &heartbeat.p2p_id {
@@ -45,6 +46,69 @@ async fn heartbeat(
         .store_context
         .metrics_store
         .store_metrics(heartbeat.metrics.clone(), node_address);
+
+    if let (Some(ref completed_task_id_str), Some(ref state_str)) =
+        (&task_info.task_id, &task_info.task_state)
+    {
+        if state_str.eq_ignore_ascii_case("COMPLETED") {
+            match uuid::Uuid::parse_str(completed_task_id_str) {
+                Ok(completed_task_id_uuid) => {
+                    let task_store = app_state.store_context.task_store.clone();
+                    if let Some(completed_task_details) =
+                        task_store.get_task_by_id(&completed_task_id_uuid)
+                    {
+                        if completed_task_details.auto_restart {
+                            log::info!(
+                                "Task {} reported as COMPLETED by node {}, auto_restart is true. Re-creating task.",
+                                completed_task_id_str,
+                                node_address
+                            );
+
+                            let new_task_request = TaskRequest {
+                                image: completed_task_details.image,
+                                name: completed_task_details.name,
+                                env_vars: completed_task_details.env_vars,
+                                command: completed_task_details.command,
+                                args: completed_task_details.args,
+                                auto_restart: Some(true),
+                            };
+
+                            let new_task_to_add = Task::from(new_task_request);
+
+                            task_store.add_task(new_task_to_add.clone());
+                            log::info!(
+                                "New task {} (name: '{}', image: '{}') created for auto-restart, originating from completed task {}.",
+                                new_task_to_add.id,
+                                new_task_to_add.name,
+                                new_task_to_add.image,
+                                completed_task_id_str
+                            );
+                        } else {
+                            log::debug!(
+                                "Task {} reported as COMPLETED by node {}, but auto_restart is false.",
+                                completed_task_id_str,
+                                node_address
+                            );
+                        }
+                    } else {
+                        log::warn!(
+                            "Task {} reported as COMPLETED by node {}, but its details were not found in TaskStore. Cannot check auto_restart.",
+                            completed_task_id_str,
+                            node_address
+                        );
+                    }
+                }
+                Err(e) => {
+                    log::warn!(
+                        "Could not parse task_id '{}' from heartbeat (node {}) into UUID for auto-restart check: {}",
+                        completed_task_id_str,
+                        node_address,
+                        e
+                    );
+                }
+            }
+        }
+    }
 
     let current_task = app_state.scheduler.get_task_for_node(node_address);
     match current_task {
@@ -73,11 +137,12 @@ pub fn heartbeat_routes() -> Scope {
 mod tests {
     use super::*;
     use crate::api::tests::helper::create_test_app_state;
+    use crate::models::node::OrchestratorNode;
     use actix_web::http::StatusCode;
     use actix_web::test;
     use actix_web::App;
     use serde_json::json;
-    use shared::models::task::TaskRequest;
+    use shared::models::task::{Task, TaskRequest, TaskState};
 
     #[actix_web::test]
     async fn test_heartbeat() {
@@ -142,6 +207,7 @@ mod tests {
             command: None,
             args: None,
             env_vars: None,
+            auto_restart: None,
         };
         app_state.store_context.task_store.add_task(task.into());
 
@@ -179,5 +245,223 @@ mod tests {
             p2p_id: None,
         };
         assert_eq!(value, heartbeat);
+    }
+
+    #[actix_web::test]
+    async fn test_heartbeat_restarts_task_when_completed_and_autorestart_true() {
+        let app_state = create_test_app_state().await;
+        let app = test::init_service(
+            App::new()
+                .app_data(app_state.clone())
+                .service(heartbeat_routes()),
+        )
+        .await;
+
+        let node_addr_str = "0x1111111111111111111111111111111111111111";
+        let node = OrchestratorNode {
+            address: Address::from_str(node_addr_str).unwrap(),
+            ip_address: "127.0.0.1".to_string(),
+            port: 8080,
+            status: NodeStatus::Healthy, // Assuming node is healthy
+            task_id: None,
+            task_state: None,
+            version: None,
+            p2p_id: None,
+            last_status_change: None,
+        };
+        app_state.store_context.node_store.add_node(node);
+
+        let original_task_req = TaskRequest {
+            image: "restartable_image".to_string(),
+            name: "restartable_task".to_string(),
+            command: Some("echo".to_string()),
+            args: Some(vec!["done".to_string()]),
+            env_vars: None,
+            auto_restart: Some(true),
+        };
+        let original_task = Task::from(original_task_req);
+        app_state
+            .store_context
+            .task_store
+            .add_task(original_task.clone());
+
+        let initial_task_count = app_state.store_context.task_store.get_all_tasks().len();
+        assert_eq!(initial_task_count, 1);
+
+        let heartbeat_payload = HeartbeatRequest {
+            address: node_addr_str.to_string(),
+            task_id: Some(original_task.id.to_string()),
+            task_state: Some("COMPLETED".to_string()),
+            metrics: None,
+            version: None,
+            timestamp: None,
+            p2p_id: None,
+        };
+
+        let req = test::TestRequest::post()
+            .uri("/heartbeat")
+            .set_json(&heartbeat_payload)
+            .to_request();
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let tasks_after_heartbeat = app_state.store_context.task_store.get_all_tasks();
+        assert_eq!(
+            tasks_after_heartbeat.len(),
+            initial_task_count + 1,
+            "A new task should have been created"
+        );
+
+        let restarted_task = tasks_after_heartbeat
+            .iter()
+            .find(|t| t.id != original_task.id && t.name == original_task.name)
+            .expect("Restarted task not found or name mismatch");
+
+        assert_eq!(restarted_task.image, original_task.image);
+        assert_eq!(restarted_task.state, TaskState::PENDING);
+        assert!(
+            restarted_task.auto_restart,
+            "Restarted task should also have auto_restart true"
+        );
+        assert_ne!(
+            restarted_task.id, original_task.id,
+            "Restarted task must have a new ID"
+        );
+
+        let original_task_in_store_after = app_state
+            .store_context
+            .task_store
+            .get_task_by_id(&original_task.id);
+        assert!(
+            original_task_in_store_after.is_some(),
+            "Original task should still exist"
+        );
+    }
+
+    #[actix_web::test]
+    async fn test_heartbeat_does_not_restart_task_when_autorestart_false() {
+        let app_state = create_test_app_state().await;
+        let app = test::init_service(
+            App::new()
+                .app_data(app_state.clone())
+                .service(heartbeat_routes()),
+        )
+        .await;
+
+        let node_addr_str = "0x2222222222222222222222222222222222222222";
+        let node = OrchestratorNode {
+            address: Address::from_str(node_addr_str).unwrap(),
+            ip_address: "127.0.0.1".to_string(),
+            port: 8080,
+            status: NodeStatus::Healthy,
+            task_id: None,
+            task_state: None,
+            version: None,
+            p2p_id: None,
+            last_status_change: None,
+        };
+        app_state.store_context.node_store.add_node(node);
+
+        let task_req = TaskRequest {
+            image: "norestart_image".to_string(),
+            name: "norestart_task".to_string(),
+            command: None,
+            args: None,
+            env_vars: None,
+            auto_restart: Some(false), // Key for this test
+        };
+        let task_to_complete = Task::from(task_req);
+        app_state
+            .store_context
+            .task_store
+            .add_task(task_to_complete.clone());
+
+        let initial_task_count = app_state.store_context.task_store.get_all_tasks().len();
+
+        let heartbeat_payload = HeartbeatRequest {
+            address: node_addr_str.to_string(),
+            task_id: Some(task_to_complete.id.to_string()),
+            task_state: Some("COMPLETED".to_string()),
+            metrics: None,
+            version: None,
+            timestamp: None,
+            p2p_id: None,
+        };
+
+        let req = test::TestRequest::post()
+            .uri("/heartbeat")
+            .set_json(&heartbeat_payload)
+            .to_request();
+        test::call_service(&app, req).await;
+
+        let tasks_after_heartbeat = app_state.store_context.task_store.get_all_tasks();
+        assert_eq!(
+            tasks_after_heartbeat.len(),
+            initial_task_count,
+            "No new task should have been created"
+        );
+    }
+
+    #[actix_web::test]
+    async fn test_heartbeat_does_not_restart_task_when_state_not_completed() {
+        let app_state = create_test_app_state().await;
+        let app = test::init_service(
+            App::new()
+                .app_data(app_state.clone())
+                .service(heartbeat_routes()),
+        )
+        .await;
+
+        let node_addr_str = "0x3333333333333333333333333333333333333333";
+        let node = OrchestratorNode {
+            address: Address::from_str(node_addr_str).unwrap(),
+            ip_address: "127.0.0.1".to_string(),
+            port: 8080,
+            status: NodeStatus::Healthy,
+            task_id: None,
+            task_state: None,
+            version: None,
+            p2p_id: None,
+            last_status_change: None,
+        };
+        app_state.store_context.node_store.add_node(node);
+
+        let task_req = TaskRequest {
+            image: "running_image".to_string(),
+            name: "running_task".to_string(),
+            command: None,
+            args: None,
+            env_vars: None,
+            auto_restart: Some(true),
+        };
+        let running_task = Task::from(task_req);
+        app_state
+            .store_context
+            .task_store
+            .add_task(running_task.clone());
+        let initial_task_count = app_state.store_context.task_store.get_all_tasks().len();
+
+        let heartbeat_payload = HeartbeatRequest {
+            address: node_addr_str.to_string(),
+            task_id: Some(running_task.id.to_string()),
+            task_state: Some("RUNNING".to_string()),
+            metrics: None,
+            version: None,
+            timestamp: None,
+            p2p_id: None,
+        };
+
+        let req = test::TestRequest::post()
+            .uri("/heartbeat")
+            .set_json(&heartbeat_payload)
+            .to_request();
+        test::call_service(&app, req).await;
+
+        let tasks_after_heartbeat = app_state.store_context.task_store.get_all_tasks();
+        assert_eq!(
+            tasks_after_heartbeat.len(),
+            initial_task_count,
+            "No new task should have been created for non-completed state"
+        );
     }
 }

--- a/crates/orchestrator/src/scheduler/mod.rs
+++ b/crates/orchestrator/src/scheduler/mod.rs
@@ -66,6 +66,7 @@ mod tests {
             state: TaskState::PENDING,
             created_at: 1,
             updated_at: None,
+            auto_restart: false,
         };
 
         state.store_context.task_store.add_task(task.clone());

--- a/crates/orchestrator/src/scheduler/plugins/newest_task.rs
+++ b/crates/orchestrator/src/scheduler/plugins/newest_task.rs
@@ -43,6 +43,7 @@ mod tests {
                 state: TaskState::PENDING,
                 created_at: 1,
                 updated_at: None,
+                auto_restart: false,
             },
             Task {
                 id: Uuid::new_v4(),
@@ -54,6 +55,7 @@ mod tests {
                 state: TaskState::PENDING,
                 created_at: 2,
                 updated_at: None,
+                auto_restart: false,
             },
         ];
 

--- a/crates/orchestrator/src/status_update/plugins/node_groups.rs
+++ b/crates/orchestrator/src/status_update/plugins/node_groups.rs
@@ -445,6 +445,7 @@ mod tests {
             state: TaskState::PENDING,
             created_at: 0,
             updated_at: None,
+            auto_restart: false,
         };
 
         let tasks = vec![task1];
@@ -531,6 +532,7 @@ mod tests {
             state: TaskState::PENDING,
             created_at: 0,
             updated_at: None,
+            auto_restart: false,
         };
 
         let tasks = vec![task];

--- a/crates/orchestrator/src/store/domains/task_store.rs
+++ b/crates/orchestrator/src/store/domains/task_store.rs
@@ -2,6 +2,7 @@ use crate::store::core::RedisStore;
 use redis::Commands;
 use shared::models::task::Task;
 use std::sync::Arc;
+use uuid::Uuid;
 
 const TASK_KEY_PREFIX: &str = "orchestrator:task:";
 const TASK_LIST_KEY: &str = "orchestrator:tasks";
@@ -24,6 +25,12 @@ impl TaskStore {
 
         // Add task ID to list of all tasks
         let _: () = con.rpush(TASK_LIST_KEY, task.id.to_string()).unwrap();
+    }
+
+    pub fn get_task_by_id(&self, id: &Uuid) -> Option<Task> {
+        let mut con = self.redis.client.get_connection().unwrap();
+        let task_key = format!("{}{}", TASK_KEY_PREFIX, id);
+        con.get(&task_key).ok()
     }
 
     pub fn get_all_tasks(&self) -> Vec<Task> {

--- a/crates/shared/src/models/task.rs
+++ b/crates/shared/src/models/task.rs
@@ -54,6 +54,7 @@ pub struct TaskRequest {
     pub env_vars: Option<std::collections::HashMap<String, String>>,
     pub command: Option<String>,
     pub args: Option<Vec<String>>,
+    pub auto_restart: Option<bool>,
 }
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct Task {
@@ -68,6 +69,8 @@ pub struct Task {
     pub created_at: i64,
     #[serde(default)]
     pub updated_at: Option<u64>,
+    #[serde(default)]
+    pub auto_restart: bool,
 }
 
 impl From<TaskRequest> for Task {
@@ -82,6 +85,7 @@ impl From<TaskRequest> for Task {
             state: TaskState::PENDING,
             created_at: Utc::now().timestamp_millis(),
             updated_at: None,
+            auto_restart: request.auto_restart.unwrap_or(false),
         }
     }
 }

--- a/crates/worker/src/docker/service.rs
+++ b/crates/worker/src/docker/service.rs
@@ -372,6 +372,7 @@ mod tests {
             state: TaskState::PENDING,
             created_at: Utc::now().timestamp_millis(),
             updated_at: None,
+            auto_restart: false,
         };
         let task_clone = task.clone();
         let state_clone = docker_service.state.clone();
@@ -423,6 +424,7 @@ mod tests {
             state: TaskState::PENDING,
             created_at: Utc::now().timestamp_millis(),
             updated_at: None,
+            auto_restart: false,
         };
 
         let task_clone = task.clone();


### PR DESCRIPTION
Closes #314 

Implements an `auto-restart` flag, enabling the orchestrator to automatically restart tasks that finish with a "COMPLETED" status.