### PR TITLE
Support multiple toploc servers in synthetic-data validation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,7 +33,8 @@ COMPUTE_POOL_ADDRESS=
 
 # Optional
 WORK_VALIDATION_CONTRACT=
-TOPLOC_SERVER_URL=
-TOPLOC_AUTH_TOKEN=
+# Toploc configurations as JSON array string
+# Example: [{"server_url": "toploc url", "auth_token": "toploc auth token", "file_prefix_filter": "optional prefix filter"}]
+TOPLOC_CONFIGS=
 S3_CREDENTIALS=
 BUCKET_NAME=

--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ watch-check:
 
 watch-validator:
 	set -a; source ${ENV_FILE}; set +a; \
-	cargo watch -w crates/validator/src -x "run --bin validator -- --validator-key $${PRIVATE_KEY_VALIDATOR} --rpc-url $${RPC_URL} --pool-id $${WORKER_COMPUTE_POOL_ID} --toploc-server-url $${TOPLOC_SERVER_URL} --toploc-auth-token $${TOPLOC_AUTH_TOKEN} --bucket-name $${BUCKET_NAME} -l $${LOG_LEVEL:-info} --toploc-grace-interval $${TOPLOC_GRACE_INTERVAL:-30}"
+	cargo watch -w crates/validator/src -x "run --bin validator -- --validator-key $${PRIVATE_KEY_VALIDATOR} --rpc-url $${RPC_URL} --pool-id $${WORKER_COMPUTE_POOL_ID} --toploc-configs '$${TOPLOC_CONFIGS:-[]}' --bucket-name $${BUCKET_NAME} -l $${LOG_LEVEL:-info} --toploc-grace-interval $${TOPLOC_GRACE_INTERVAL:-30}"
 
 watch-orchestrator:
 	set -a; source ${ENV_FILE}; set +a; \

--- a/crates/validator/Dockerfile
+++ b/crates/validator/Dockerfile
@@ -12,11 +12,10 @@ ENV S3_CREDENTIALS=""
 ENV BUCKET_NAME=""
 ENV LOG_LEVEL=""
 ENV REDIS_URL="redis://localhost:6380"
-ENV TOPLOC_SERVER_URL=""
-ENV TOPLOC_AUTH_TOKEN=""
 ENV TOPLOC_GRACE_INTERVAL="15"
 ENV TOPLOC_WORK_VALIDATION_INTERVAL="15"
 ENV TOPLOC_WORK_VALIDATION_UNKNOWN_STATUS_EXPIRY_SECONDS="120"
+ENV TOPLOC_CONFIGS=""
 ENV DISABLE_HARDWARE_VALIDATION="false"
 ENV VALIDATOR_PENALTY="1"
 
@@ -26,8 +25,7 @@ exec /usr/local/bin/validator \
 --validator-key "$VALIDATOR_KEY" \
 --discovery-url "$DISCOVERY_URL" \
 $([ ! -z "$POOL_ID" ] && echo "--pool-id $POOL_ID") \
-$([ ! -z "$TOPLOC_SERVER_URL" ] && echo "--toploc-server-url $TOPLOC_SERVER_URL") \
-$([ ! -z "$TOPLOC_AUTH_TOKEN" ] && echo "--toploc-auth-token $TOPLOC_AUTH_TOKEN") \
+$([ ! -z "$TOPLOC_CONFIGS" ] && echo "--toploc-configs $TOPLOC_CONFIGS") \
 $([ ! -z "$BUCKET_NAME" ] && echo "--bucket-name $BUCKET_NAME") \
 $([ ! -z "$LOG_LEVEL" ] && echo "--log-level $LOG_LEVEL") \
 $([ ! -z "$REDIS_URL" ] && echo "--redis-url $REDIS_URL") \

--- a/crates/validator/src/main.rs
+++ b/crates/validator/src/main.rs
@@ -234,10 +234,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 let toploc_config = ToplocConfig {
                     server_url: args.toploc_server_url.unwrap(),
                     auth_token: args.toploc_auth_token,
-                    grace_interval: args.toploc_grace_interval,
-                    work_validation_interval: args.toploc_work_validation_interval,
-                    unknown_status_expiry_seconds: args
-                        .toploc_work_validation_unknown_status_expiry_seconds,
+                    file_prefix_filter: None,
                 };
                 info!(
                     "Synthetic validator has penalty: {} ({})",
@@ -250,12 +247,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     pool_id,
                     validator,
                     contracts.prime_network.clone(),
-                    toploc_config,
+                    vec![toploc_config],
                     penalty,
                     s3_credentials,
                     args.bucket_name,
                     redis_store,
                     cancellation_token,
+                    args.toploc_grace_interval,
+                    args.toploc_work_validation_interval,
+                    args.toploc_work_validation_unknown_status_expiry_seconds,
                 ))
             }
             None => {

--- a/crates/validator/src/main.rs
+++ b/crates/validator/src/main.rs
@@ -264,9 +264,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     args.bucket_name,
                     redis_store,
                     cancellation_token,
-                    args.toploc_grace_interval,
                     args.toploc_work_validation_interval,
                     args.toploc_work_validation_unknown_status_expiry_seconds,
+                    args.toploc_grace_interval,
                 ))
             }
             None => {

--- a/crates/validator/src/validators/synthetic_data.rs
+++ b/crates/validator/src/validators/synthetic_data.rs
@@ -40,8 +40,6 @@ pub enum ProcessWorkKeyError {
     MaxAttemptsReached(String),
     /// Generic error to encapsulate unexpected errors.
     GenericError(anyhow::Error),
-    /// Error when no matching toploc config is found for the file name.
-    NoMatchingToplocConfig,
 }
 
 impl From<anyhow::Error> for ProcessWorkKeyError {
@@ -70,9 +68,6 @@ impl fmt::Display for ProcessWorkKeyError {
             }
             ProcessWorkKeyError::GenericError(err) => {
                 write!(f, "Generic error: {}", err)
-            }
-            ProcessWorkKeyError::NoMatchingToplocConfig => {
-                write!(f, "No matching toploc config found")
             }
         }
     }

--- a/crates/validator/src/validators/synthetic_data.rs
+++ b/crates/validator/src/validators/synthetic_data.rs
@@ -78,7 +78,7 @@ impl fmt::Display for ProcessWorkKeyError {
     }
 }
 
-#[derive(Clone, Default, Debug, PartialEq)]
+#[derive(Clone, Default, Debug, PartialEq, Serialize, Deserialize)]
 pub struct ToplocConfig {
     pub server_url: String,
     pub auth_token: Option<String>,
@@ -759,7 +759,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_toploc_config_for_file_name() -> Result<(), Error> {
-        let configs = [ToplocConfig {
+        let configs = [
+            ToplocConfig {
                 server_url: "http://localhost:8080".to_string(),
                 file_prefix_filter: Some("model1".to_string()),
                 ..Default::default()
@@ -768,7 +769,8 @@ mod tests {
                 server_url: "http://localhost:8081".to_string(),
                 file_prefix_filter: Some("model2".to_string()),
                 ..Default::default()
-            }];
+            },
+        ];
 
         let file_name = "model1/dataset/groupid-groupsize-filenumber-idx";
         let config = configs

--- a/crates/validator/src/validators/synthetic_data.rs
+++ b/crates/validator/src/validators/synthetic_data.rs
@@ -269,24 +269,6 @@ impl SyntheticDataValidator {
 
         let toploc_config = self.get_toploc_config_for_file_name(&file_name)?;
 
-        // Returns a file name like /model/dataset/groupid-groupsize-filenumber-idx
-
-        // We need to wait for all submissions before triggering the validation
-
-        // We actually need group information here since toploc wants all files at once
-        // http://localhost:8000/validategroup/outputs/step_2/meow - will be adding -$i  to the end of the file name
-        // this is important for the template of the task
-        /*
-        {
-            "file_shas": [
-              "c94d6199fd9fca27613f4def6bf039110435cc9ac645d50db9f756f70fb1dec2", "8d0f0079c99da0bb7573d913cfece7677f00f6c836cc09979944f0e2765248c7"
-            ],
-            "group_id": "string",
-            "file_number": 0,
-            "group_size": 2
-          }
-        */
-
         let validate_url = format!("{}/validate/{}", toploc_config.config.server_url, file_name);
         info!(
             "Triggering remote toploc validation for {} {}",
@@ -577,7 +559,6 @@ impl SyntheticDataValidator {
             debug!("Key {} has {} work units", work_key, work_info.work_units);
 
             // Invalidate work if work units exceed threshold
-            // TODO: This has to be adjusted for synthetic-II !
             if work_info.work_units > U256::from(1) {
                 if let Err(e) = self_arc.invalidate_work(work_key).await {
                     error!("Failed to invalidate work {}: {}", work_key, e);

--- a/deployment/k8s/validator-chart/templates/secret.yaml
+++ b/deployment/k8s/validator-chart/templates/secret.yaml
@@ -6,8 +6,8 @@ metadata:
 type: Opaque
 data:
   validatorKey: {{ .Values.secrets.validatorKey | b64enc }}
-  {{- if .Values.secrets.toplocAuthToken }}
-  toplocAuthToken: {{ .Values.secrets.toplocAuthToken | b64enc }}
+  {{- if .Values.secrets.toplocConfigs }}
+  toplocConfigs: {{ .Values.secrets.toplocConfigs | b64enc }}
   {{- end }}
   {{- if .Values.secrets.s3Credentials }}
   s3Credentials: {{ .Values.secrets.s3Credentials | b64enc }}

--- a/deployment/k8s/validator-chart/templates/validator-deployment.yaml
+++ b/deployment/k8s/validator-chart/templates/validator-deployment.yaml
@@ -49,16 +49,12 @@ spec:
               value: {{ .Values.env.DISCOVERY_URL }}
             - name: REDIS_URL
               value: "redis://{{ include "validator.redisName" . }}:6379"
-            {{- if .Values.env.TOPLOC_SERVER_URL }}
-            - name: TOPLOC_SERVER_URL
-              value: {{ .Values.env.TOPLOC_SERVER_URL }}
-            {{- end }}
-            {{- if .Values.secrets.toplocAuthToken }}
-            - name: TOPLOC_AUTH_TOKEN
+            {{- if .Values.secrets.toplocConfigs }}
+            - name: TOPLOC_CONFIGS
               valueFrom:
                 secretKeyRef:
                   name: {{ include "validator.secretName" . }}
-                  key: toplocAuthToken
+                  key: toplocConfigs
             {{- end }}
             - name: LOG_LEVEL
               value: "{{ .Values.env.LOG_LEVEL }}"

--- a/deployment/k8s/validator-chart/values.example.yaml
+++ b/deployment/k8s/validator-chart/values.example.yaml
@@ -7,7 +7,6 @@ env:
   DISCOVERY_URL: "http://discovery.example-namespace:8089"
   BUCKET_NAME: "example-development-bucket"
   LOG_LEVEL: "info"
-  TOPLOC_SERVER_URL: "https://example-service.example.io"
   TOPLOC_GRACE_INTERVAL: "1"
   TOPLOC_WORK_VALIDATION_INTERVAL: "35"
   DISABLE_HARDWARE_VALIDATION: "true"
@@ -15,5 +14,5 @@ env:
 
 secrets:
   validatorKey: "private key"
-  toplocAuthToken: "exampleAuthTokenHere"
   s3Credentials: "base64EncodedS3CredentialsGoHere"
+  toplocConfigs: "toploc configs"


### PR DESCRIPTION
Previously a validator was connected to a single toploc server. Now we want to support validating multiple models hence have to support multiple toploc servers. 
You can simply pass in a configuration of toploc servers now that use filename prefix matching to route the files to the correct server: 
```
TOPLOC_CONFIGS="[{\"server_url\":\"http://localhost:8080\",\"auth_token\":\"token\", \"file_prefix_filter\":\"model_name\"}]"
```