### PR TITLE
Refactor storage & scheduling variables

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7237,6 +7237,7 @@ dependencies = [
  "nalgebra",
  "rand 0.9.1",
  "redis",
+ "regex",
  "serde",
  "serde_json",
  "tokio",

--- a/crates/orchestrator/src/api/routes/heartbeat.rs
+++ b/crates/orchestrator/src/api/routes/heartbeat.rs
@@ -141,7 +141,11 @@ mod tests {
             name: "test".to_string(),
             ..Default::default()
         };
-        app_state.store_context.task_store.add_task(task.into());
+        let task = match task.try_into() {
+            Ok(task) => task,
+            Err(e) => panic!("Failed to convert TaskRequest to Task: {}", e),
+        };
+        app_state.store_context.task_store.add_task(task);
 
         let req = test::TestRequest::post()
             .uri("/heartbeat")

--- a/crates/orchestrator/src/api/routes/storage.rs
+++ b/crates/orchestrator/src/api/routes/storage.rs
@@ -113,11 +113,11 @@ async fn request_upload(
                 match plugin.get_node_group(address) {
                     Ok(Some(group)) => {
                         group_id = Some(group.id.clone());
-                        file_name = file_name.replace("${node_group_id}", &group.id);
+                        file_name = file_name.replace("${NODE_GROUP_ID}", &group.id);
                         file_name =
-                            file_name.replace("${node_group_size}", &group.nodes.len().to_string());
+                            file_name.replace("${NODE_GROUP_SIZE}", &group.nodes.len().to_string());
                         let idx = plugin.get_idx_in_group(&group, address).unwrap();
-                        file_name = file_name.replace("${node_group_index}", &idx.to_string());
+                        file_name = file_name.replace("${NODE_GROUP_INDEX}", &idx.to_string());
                     }
                     Ok(None) => {
                         log::warn!(
@@ -174,11 +174,11 @@ async fn request_upload(
     };
     let file_number = upload_count.saturating_sub(1);
 
-    if file_name.contains("${upload_count}") {
-        file_name = file_name.replace("${upload_count}", &upload_count.to_string());
+    if file_name.contains("${TOTAL_UPLOAD_COUNT_AFTER}") {
+        file_name = file_name.replace("${TOTAL_UPLOAD_COUNT_AFTER}", &upload_count.to_string());
     }
-    if file_name.contains("${file_number}") {
-        file_name = file_name.replace("${file_number}", &file_number.to_string());
+    if file_name.contains("${CURRENT_FILE_INDEX}") {
+        file_name = file_name.replace("${CURRENT_FILE_INDEX}", &file_number.to_string());
     }
 
     let file_size = &request_upload.file_size;
@@ -287,7 +287,7 @@ pub fn storage_routes() -> Scope {
 
 fn generate_file_name(template: &str, original_name: &str) -> String {
     let mut file_name = template.to_string();
-    file_name = file_name.replace("${original_name}", original_name);
+    file_name = file_name.replace("${ORIGINAL_NAME}", original_name);
     file_name
 }
 
@@ -308,7 +308,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_generate_file_name() {
-        let template = "test/${original_name}";
+        let template = "test/${ORIGINAL_NAME}";
         let original_name = "test";
         let file_name = generate_file_name(template, original_name);
         assert_eq!(file_name, "test/test");
@@ -323,7 +323,7 @@ mod tests {
             image: "test-image".to_string(),
             name: "test-task".to_string(),
             storage_config: Some(StorageConfig {
-                file_name_template: Some("model_123/user_uploads/${original_name}".to_string()),
+                file_name_template: Some("model_123/user_uploads/${ORIGINAL_NAME}".to_string()),
             }),
             ..Default::default()
         };
@@ -439,7 +439,7 @@ mod tests {
             name: "test-task".to_string(),
             storage_config: Some(StorageConfig {
                 file_name_template: Some(
-                    "model_xyz/dataset_1/${node_group_id}-${node_group_size}-${node_group_index}-${upload_count}-${file_number}.parquet".to_string(),
+                    "model_xyz/dataset_1/${NODE_GROUP_ID}-${NODE_GROUP_SIZE}-${NODE_GROUP_INDEX}-${TOTAL_UPLOAD_COUNT_AFTER}-${CURRENT_FILE_INDEX}.parquet".to_string(),
                 ),
             }),
             ..Default::default()
@@ -572,7 +572,8 @@ mod tests {
             name: "test-task".to_string(),
             storage_config: Some(StorageConfig {
                 file_name_template: Some(
-                    "model_xyz/dataset_1/${upload_count}-${file_number}.parquet".to_string(),
+                    "model_xyz/dataset_1/${TOTAL_UPLOAD_COUNT_AFTER}-${CURRENT_FILE_INDEX}.parquet"
+                        .to_string(),
                 ),
             }),
             ..Default::default()

--- a/crates/orchestrator/src/plugins/node_groups/scheduler_impl.rs
+++ b/crates/orchestrator/src/plugins/node_groups/scheduler_impl.rs
@@ -99,7 +99,7 @@ impl SchedulerPlugin for NodeGroupsPlugin {
 
                 // Temporary hack to get the upload count
                 let pattern = format!("upload:{}:{}:*", node_address, group.id);
-                let upload_count = match self.store.client.get_connection() {
+                let total_upload_count = match self.store.client.get_connection() {
                     Ok(mut conn) => {
                         let mut keys: Vec<String> = Vec::new();
                         match conn.scan_match(&pattern) {
@@ -121,7 +121,10 @@ impl SchedulerPlugin for NodeGroupsPlugin {
                     }
                 };
                 // File number starts with 0 for the first file, while filecount is at 1
-                let file_number = upload_count.parse::<u32>().unwrap_or(0).saturating_sub(1);
+                let last_file_idx = total_upload_count
+                    .parse::<u32>()
+                    .unwrap_or(0)
+                    .saturating_sub(1);
 
                 let mut env_vars = task_clone.env_vars.unwrap_or_default();
                 env_vars.insert("GROUP_INDEX".to_string(), idx.to_string());
@@ -131,8 +134,8 @@ impl SchedulerPlugin for NodeGroupsPlugin {
                         .replace("${GROUP_SIZE}", &group.nodes.len().to_string())
                         .replace("${NEXT_P2P_ADDRESS}", &next_p2p_id)
                         .replace("${GROUP_ID}", &group.id)
-                        .replace("${UPLOAD_COUNT}", &upload_count.to_string())
-                        .replace("${FILE_NUMBER}", &file_number.to_string());
+                        .replace("${TOTAL_UPLOAD_COUNT}", &total_upload_count.to_string())
+                        .replace("${LAST_FILE_IDX}", &last_file_idx.to_string());
 
                     *value = new_value;
                 }
@@ -144,8 +147,8 @@ impl SchedulerPlugin for NodeGroupsPlugin {
                                 .replace("${GROUP_SIZE}", &group.nodes.len().to_string())
                                 .replace("${NEXT_P2P_ADDRESS}", &next_p2p_id)
                                 .replace("${GROUP_ID}", &group.id)
-                                .replace("${UPLOAD_COUNT}", &upload_count.to_string())
-                                .replace("${FILE_NUMBER}", &file_number.to_string())
+                                .replace("${TOTAL_UPLOAD_COUNT}", &total_upload_count.to_string())
+                                .replace("${LAST_FILE_IDX}", &last_file_idx.to_string())
                         })
                         .collect::<Vec<String>>()
                 });

--- a/crates/orchestrator/src/plugins/node_groups/tests.rs
+++ b/crates/orchestrator/src/plugins/node_groups/tests.rs
@@ -400,8 +400,11 @@ async fn test_group_scheduling() {
     env_vars.insert("RANK".to_string(), "${GROUP_INDEX}".to_string());
     env_vars.insert("WORLD_SIZE".to_string(), "${GROUP_SIZE}".to_string());
     env_vars.insert("GROUP_ID".to_string(), "${GROUP_ID}".to_string());
-    env_vars.insert("UPLOAD_COUNT".to_string(), "${UPLOAD_COUNT}".to_string());
-    env_vars.insert("FILE_NUMBER".to_string(), "${FILE_NUMBER}".to_string());
+    env_vars.insert(
+        "TOTAL_UPLOAD_COUNT".to_string(),
+        "${TOTAL_UPLOAD_COUNT}".to_string(),
+    );
+    env_vars.insert("LAST_FILE_IDX".to_string(), "${LAST_FILE_IDX}".to_string());
 
     let task1 = Task {
         id: Uuid::new_v4(),
@@ -419,9 +422,9 @@ async fn test_group_scheduling() {
             "--group-id".to_string(),
             "${GROUP_ID}".to_string(),
             "--upload-count".to_string(),
-            "${UPLOAD_COUNT}".to_string(),
+            "${TOTAL_UPLOAD_COUNT}".to_string(),
             "--file-number".to_string(),
-            "${FILE_NUMBER}".to_string(),
+            "${LAST_FILE_IDX}".to_string(),
         ]),
         state: TaskState::PENDING,
         created_at: 0,
@@ -471,8 +474,8 @@ async fn test_group_scheduling() {
     assert_eq!(env_vars_1.get("WORLD_SIZE").unwrap(), "2");
     assert_eq!(task_node_1.args.as_ref().unwrap()[3], "model/Qwen3-14B-0.2");
     assert_ne!(env_vars_1.get("GROUP_ID").unwrap(), "${GROUP_ID}");
-    assert_eq!(env_vars_1.get("UPLOAD_COUNT").unwrap(), "1");
-    assert_eq!(env_vars_1.get("FILE_NUMBER").unwrap(), "0");
+    assert_eq!(env_vars_1.get("TOTAL_UPLOAD_COUNT").unwrap(), "1");
+    assert_eq!(env_vars_1.get("LAST_FILE_IDX").unwrap(), "0");
     assert_eq!(task_node_1.args.as_ref().unwrap()[9], "1"); // Check upload count in args
 
     assert_eq!(filtered_tasks_2.len(), 1);
@@ -483,8 +486,8 @@ async fn test_group_scheduling() {
     assert_eq!(env_vars_2.get("WORLD_SIZE").unwrap(), "2");
     assert_eq!(task_node_2.args.as_ref().unwrap()[3], "model/Qwen3-14B-1.2");
     assert_ne!(env_vars_2.get("GROUP_ID").unwrap(), "${GROUP_ID}");
-    assert_eq!(env_vars_2.get("UPLOAD_COUNT").unwrap(), "0");
-    assert_eq!(env_vars_2.get("FILE_NUMBER").unwrap(), "0");
+    assert_eq!(env_vars_2.get("TOTAL_UPLOAD_COUNT").unwrap(), "0");
+    assert_eq!(env_vars_2.get("LAST_FILE_IDX").unwrap(), "0");
     assert_eq!(task_node_2.args.as_ref().unwrap()[9], "0"); // Check upload count in args
 
     assert_eq!(task_node_1.id, task_node_2.id);

--- a/crates/shared/Cargo.toml
+++ b/crates/shared/Cargo.toml
@@ -32,3 +32,4 @@ google-cloud-storage = "0.24.0"
 base64 = "0.22.1"
 chrono = { workspace = true, features = ["serde"] }
 async-trait = "0.1.88"
+regex = "1.11.1"


### PR DESCRIPTION
Scheduler variables (calculated before upload):
```
// This is the upload count of all files that we already have (excluding this one). 
${TOTAL_UPLOAD_COUNT}
// Last file that we have uploaded (file number in storage)
${LAST_FILE_IDX}
```

Storage variables (calculated during upload):
```
// more clear that it starts with 0
${file_number} => ${CURRENT_FILE_INDEX} 

${upload_count} => ${TOTAL_UPLOAD_COUNT_AFTER}
```