### PR TITLE
Feature: Advanced Webhooks

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,3 +38,7 @@ WORK_VALIDATION_CONTRACT=
 TOPLOC_CONFIGS=
 S3_CREDENTIALS=
 BUCKET_NAME=
+
+# Webhook configurations as JSON array string
+# Example: [{"url": "webhook url", "bearer_token": "webhook bearer token"}]
+WEBHOOK_CONFIGS=

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5620,7 +5620,12 @@ dependencies = [
  "google-cloud-storage",
  "hex",
  "log",
+<<<<<<< HEAD
  "prometheus 0.14.0",
+=======
+ "mockito",
+ "prometheus",
+>>>>>>> 162ff69 (introduce advanced webhook plugin)
  "rand 0.9.1",
  "redis",
  "redis-test",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5620,12 +5620,8 @@ dependencies = [
  "google-cloud-storage",
  "hex",
  "log",
-<<<<<<< HEAD
- "prometheus 0.14.0",
-=======
  "mockito",
- "prometheus",
->>>>>>> 162ff69 (introduce advanced webhook plugin)
+ "prometheus 0.14.0",
  "rand 0.9.1",
  "redis",
  "redis-test",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ nalgebra = "0.33.2"
 redis = "0.28.1"
 redis-test = "0.8.0"
 stun = "0.7.0"
+mockito = "1.7.0"
 
 [workspace.package]
 version = "0.2.11"

--- a/crates/orchestrator/Cargo.toml
+++ b/crates/orchestrator/Cargo.toml
@@ -29,3 +29,6 @@ shared = { workspace = true }
 tokio = { workspace = true }
 url = { workspace = true }
 uuid = { workspace = true }
+
+[dev-dependencies]
+mockito = { workspace = true }

--- a/crates/orchestrator/Dockerfile
+++ b/crates/orchestrator/Dockerfile
@@ -21,10 +21,10 @@ ENV S3_CREDENTIALS=""
 ENV BUCKET_NAME=""
 ENV LOG_LEVEL=""
 ENV HOURLY_S3_UPLOAD_LIMIT="2"
-ENV WEBHOOK_URLS=""
 ENV MODE="full"
 ENV NODE_GROUP_CONFIGS=""
 ENV NODE_GROUP_MANAGEMENT_INTERVAL="10"
+ENV WEBHOOK_CONFIGS=""
 
 RUN echo '#!/bin/sh\n\
 exec /usr/local/bin/orchestrator \
@@ -44,7 +44,6 @@ $([ "$DISABLE_EJECTION" = "true" ] && echo "--disable-ejection") \
 $([ ! -z "$BUCKET_NAME" ] && echo "--bucket-name $BUCKET_NAME") \
 $([ ! -z "$LOG_LEVEL" ] && echo "--log-level $LOG_LEVEL") \
 $([ ! -z "$HOURLY_S3_UPLOAD_LIMIT" ] && echo "--hourly-s3-upload-limit $HOURLY_S3_UPLOAD_LIMIT") \
-$([ ! -z "$WEBHOOK_URLS" ] && echo "--webhook-urls $WEBHOOK_URLS") \
 $([ ! -z "$NODE_GROUP_MANAGEMENT_INTERVAL" ] && echo "--node-group-management-interval $NODE_GROUP_MANAGEMENT_INTERVAL") \
 "$@"' > /entrypoint.sh && \
 chmod +x /entrypoint.sh

--- a/crates/orchestrator/src/api/routes/storage.rs
+++ b/crates/orchestrator/src/api/routes/storage.rs
@@ -426,6 +426,7 @@ mod tests {
             app_state.redis_store.clone(),
             app_state.store_context.clone(),
             None,
+            None,
         );
 
         let _ = plugin

--- a/crates/orchestrator/src/api/tests/helper.rs
+++ b/crates/orchestrator/src/api/tests/helper.rs
@@ -107,6 +107,7 @@ pub async fn create_test_app_state_with_nodegroups() -> Data<AppState> {
         store.clone(),
         store_context.clone(),
         None,
+        None,
     )));
 
     let mock_storage = MockStorageProvider::new();

--- a/crates/orchestrator/src/events/mod.rs
+++ b/crates/orchestrator/src/events/mod.rs
@@ -1,7 +1,6 @@
 use anyhow::Result;
 use shared::models::task::Task;
 
-// TODO: Shouldnt this be handled in a tokio trhead?
 pub trait TaskObserver: Send + Sync {
     fn on_task_created(&self, task: &Task) -> Result<()>;
     fn on_task_deleted(&self, task: Option<Task>) -> Result<()>;

--- a/crates/orchestrator/src/metrics/mod.rs
+++ b/crates/orchestrator/src/metrics/mod.rs
@@ -1,4 +1,5 @@
 use prometheus::{GaugeVec, Opts, Registry, TextEncoder};
+pub mod webhook_sender;
 
 pub struct MetricsContext {
     pub compute_task_gauges: GaugeVec,

--- a/crates/orchestrator/src/metrics/webhook_sender.rs
+++ b/crates/orchestrator/src/metrics/webhook_sender.rs
@@ -1,0 +1,44 @@
+use crate::plugins::webhook::WebhookPlugin;
+use crate::store::core::StoreContext;
+use anyhow::Result;
+use log::info;
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::time::interval;
+
+pub struct MetricsWebhookSender {
+    store_context: Arc<StoreContext>,
+    webhook_plugins: Vec<WebhookPlugin>,
+    last_sent_metrics: HashMap<String, f64>,
+}
+
+impl MetricsWebhookSender {
+    pub fn new(store_context: Arc<StoreContext>, webhook_plugins: Vec<WebhookPlugin>) -> Self {
+        Self {
+            store_context,
+            webhook_plugins,
+            last_sent_metrics: HashMap::new(),
+        }
+    }
+
+    pub async fn run(&mut self) -> Result<()> {
+        let mut interval = interval(Duration::from_secs(15));
+        loop {
+            interval.tick().await;
+            let metrics = self
+                .store_context
+                .metrics_store
+                .get_aggregate_metrics_for_all_tasks();
+
+            if metrics != self.last_sent_metrics {
+                info!("Sending {} metrics via webhook", metrics.len());
+                for plugin in &self.webhook_plugins {
+                    let _ = plugin.send_metrics_updated(metrics.clone()).await;
+                }
+                // Update last sent metrics
+                self.last_sent_metrics = metrics.clone();
+            }
+        }
+    }
+}

--- a/crates/orchestrator/src/plugins/node_groups/tests.rs
+++ b/crates/orchestrator/src/plugins/node_groups/tests.rs
@@ -103,7 +103,7 @@ async fn test_group_formation_and_dissolution() {
         compute_requirements: None,
     };
 
-    let plugin = NodeGroupsPlugin::new(vec![config], store.clone(), store_context, None);
+    let plugin = NodeGroupsPlugin::new(vec![config], store.clone(), store_context, None, None);
 
     let task = Task {
         scheduling_config: Some(SchedulingConfig {
@@ -195,6 +195,7 @@ async fn test_group_formation_with_multiple_configs() {
         store.clone(),
         store_context,
         None,
+        None,
     );
     let task = Task {
         scheduling_config: Some(SchedulingConfig {
@@ -275,7 +276,7 @@ async fn test_group_formation_with_requirements_and_single_node() {
         compute_requirements: Some(requirements),
     };
 
-    let plugin = NodeGroupsPlugin::new(vec![config], store.clone(), store_context, None);
+    let plugin = NodeGroupsPlugin::new(vec![config], store.clone(), store_context, None, None);
     let task = Task {
         scheduling_config: Some(SchedulingConfig {
             plugins: Some(HashMap::from([(
@@ -337,7 +338,7 @@ async fn test_group_formation_with_requirements_and_multiple_nodes() {
         compute_requirements: Some(requirements),
     };
 
-    let plugin = NodeGroupsPlugin::new(vec![config], store.clone(), store_context, None);
+    let plugin = NodeGroupsPlugin::new(vec![config], store.clone(), store_context, None, None);
     let task = Task {
         scheduling_config: Some(SchedulingConfig {
             plugins: Some(HashMap::from([(
@@ -420,7 +421,7 @@ async fn test_group_scheduling() {
         compute_requirements: None,
     };
 
-    let plugin = NodeGroupsPlugin::new(vec![config], store.clone(), store_context, None);
+    let plugin = NodeGroupsPlugin::new(vec![config], store.clone(), store_context, None, None);
 
     let task = Task {
         scheduling_config: Some(SchedulingConfig {
@@ -557,7 +558,7 @@ async fn test_group_scheduling_without_tasks() {
         max_group_size: 5,
         compute_requirements: None,
     };
-    let plugin = NodeGroupsPlugin::new(vec![config], store.clone(), store_context, None);
+    let plugin = NodeGroupsPlugin::new(vec![config], store.clone(), store_context, None, None);
     let node1 = create_test_node(
         "0x1234567890123456789012345678901234567890",
         NodeStatus::Healthy,
@@ -597,7 +598,7 @@ async fn test_group_formation_with_max_size() {
         max_group_size: 2,
         compute_requirements: None,
     };
-    let plugin = NodeGroupsPlugin::new(vec![config], store.clone(), store_context, None);
+    let plugin = NodeGroupsPlugin::new(vec![config], store.clone(), store_context, None, None);
     let task = Task {
         scheduling_config: Some(SchedulingConfig {
             plugins: Some(HashMap::from([(
@@ -715,7 +716,7 @@ async fn test_node_groups_with_allowed_topologies() {
         compute_requirements: None,
     };
 
-    let plugin = NodeGroupsPlugin::new(vec![config], store.clone(), store_context, None);
+    let plugin = NodeGroupsPlugin::new(vec![config], store.clone(), store_context, None, None);
 
     let node1 = create_test_node(
         "0x1234567890123456789012345678901234567890",
@@ -796,7 +797,7 @@ async fn test_node_cannot_be_in_multiple_groups() {
     };
 
     // Set max_group_size to 2, so groups can only have 2 nodes
-    let plugin = NodeGroupsPlugin::new(vec![config], store.clone(), store_context, None);
+    let plugin = NodeGroupsPlugin::new(vec![config], store.clone(), store_context, None, None);
 
     let all_nodes = plugin.store_context.node_store.get_nodes();
     assert_eq!(all_nodes.len(), 0, "No nodes should be in the store");
@@ -993,7 +994,7 @@ async fn test_reformation_on_death() {
         max_group_size: 2,
         compute_requirements: None,
     };
-    let plugin = NodeGroupsPlugin::new(vec![config], store.clone(), store_context, None);
+    let plugin = NodeGroupsPlugin::new(vec![config], store.clone(), store_context, None, None);
     let task = Task {
         scheduling_config: Some(SchedulingConfig {
             plugins: Some(HashMap::from([(
@@ -1101,7 +1102,13 @@ async fn ensure_config_names_are_unique() {
         compute_requirements: None,
     };
 
-    let _plugin = NodeGroupsPlugin::new(vec![config1, config2], store.clone(), store_context, None);
+    let _plugin = NodeGroupsPlugin::new(
+        vec![config1, config2],
+        store.clone(),
+        store_context,
+        None,
+        None,
+    );
 }
 
 #[tokio::test]
@@ -1118,7 +1125,7 @@ async fn ensure_config_validation() {
         compute_requirements: None,
     };
 
-    let _plugin = NodeGroupsPlugin::new(vec![config], store.clone(), store_context, None);
+    let _plugin = NodeGroupsPlugin::new(vec![config], store.clone(), store_context, None, None);
 }
 
 #[tokio::test]
@@ -1127,7 +1134,7 @@ async fn test_get_idx_in_group() {
     let context_store = store.clone();
     let store_context = Arc::new(StoreContext::new(context_store));
 
-    let plugin = NodeGroupsPlugin::new(vec![], store.clone(), store_context, None);
+    let plugin = NodeGroupsPlugin::new(vec![], store.clone(), store_context, None, None);
 
     let node1 = create_test_node(
         "0x1234567890123456789012345678901234567890",
@@ -1182,7 +1189,7 @@ async fn test_get_idx_in_group_not_found() {
     let context_store = store.clone();
     let store_context = Arc::new(StoreContext::new(context_store));
 
-    let plugin = NodeGroupsPlugin::new(vec![], store.clone(), store_context, None);
+    let plugin = NodeGroupsPlugin::new(vec![], store.clone(), store_context, None, None);
 
     let group = NodeGroup {
         id: "test-group".to_string(),
@@ -1213,6 +1220,7 @@ async fn test_task_observer() {
         vec![node_group_config],
         plugin_store,
         plugin_store_context,
+        None,
         None,
     );
 
@@ -1340,6 +1348,7 @@ async fn test_building_largest_possible_groups() {
         plugin_store,
         plugin_store_context,
         None,
+        None,
     );
 
     // Create and add 3 nodes
@@ -1457,6 +1466,7 @@ async fn test_group_formation_priority() {
         store.clone(),
         store_context,
         None,
+        None,
     );
 
     // Add 4 healthy nodes
@@ -1545,7 +1555,7 @@ async fn test_multiple_groups_same_configuration() {
         compute_requirements: None,
     };
 
-    let plugin = NodeGroupsPlugin::new(vec![config], store.clone(), store_context, None);
+    let plugin = NodeGroupsPlugin::new(vec![config], store.clone(), store_context, None, None);
 
     // Create task that requires this configuration
     let task = Task {

--- a/crates/orchestrator/src/plugins/webhook/mod.rs
+++ b/crates/orchestrator/src/plugins/webhook/mod.rs
@@ -1,20 +1,192 @@
-use std::time::Duration;
+use std::{sync::Arc, time::Duration};
 
 use anyhow::Error;
-use serde_json::json;
+use serde::{Deserialize, Serialize};
 
 use crate::models::node::{NodeStatus, OrchestratorNode};
 
 use super::{Plugin, StatusUpdatePlugin};
 use log::{debug, error};
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "event", content = "data")]
+pub enum WebhookEvent {
+    #[serde(rename = "node.status_changed")]
+    NodeStatusChanged {
+        node_address: String,
+        ip_address: String,
+        port: u16,
+        old_status: String,
+        new_status: String,
+    },
+    #[serde(rename = "group.created")]
+    GroupCreated {
+        group_id: String,
+        configuration_name: String,
+        nodes: Vec<String>,
+    },
+    #[serde(rename = "group.destroyed")]
+    GroupDestroyed {
+        group_id: String,
+        configuration_name: String,
+        nodes: Vec<String>,
+    },
+    #[serde(rename = "metrics.updated")]
+    MetricsUpdated {
+        #[serde(flatten)]
+        metrics: std::collections::HashMap<String, f64>,
+    },
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct WebhookPayload {
+    #[serde(flatten)]
+    pub event: WebhookEvent,
+    pub timestamp: String,
+}
+
+impl WebhookPayload {
+    pub fn new(event: WebhookEvent) -> Self {
+        #[cfg(test)]
+        let timestamp = "2024-01-01T00:00:00Z".to_string();
+        #[cfg(not(test))]
+        let timestamp = chrono::Utc::now().to_rfc3339();
+
+        Self { event, timestamp }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WebhookConfig {
+    pub url: String,
+    pub bearer_token: Option<String>,
+}
+
+#[derive(Debug, Clone)]
 pub struct WebhookPlugin {
     webhook_url: String,
+    client: Arc<reqwest::Client>,
 }
 
 impl WebhookPlugin {
-    pub fn new(webhook_url: String) -> Self {
-        Self { webhook_url }
+    pub fn new(webhook_config: WebhookConfig) -> Self {
+        let client = Arc::new(
+            reqwest::Client::builder()
+                .default_headers({
+                    let mut headers = reqwest::header::HeaderMap::new();
+                    if let Some(token) = &webhook_config.bearer_token {
+                        headers.insert(
+                            reqwest::header::AUTHORIZATION,
+                            reqwest::header::HeaderValue::from_str(&format!("Bearer {}", token))
+                                .expect("Invalid token"),
+                        );
+                    }
+                    headers
+                })
+                .build()
+                .expect("Failed to build HTTP client"),
+        );
+
+        Self {
+            webhook_url: webhook_config.url,
+            client,
+        }
+    }
+
+    async fn send_event(&self, event: WebhookEvent) -> Result<(), Error> {
+        let payload = WebhookPayload::new(event);
+        let webhook_url = self.webhook_url.clone();
+        let client = self.client.clone();
+
+        #[cfg(not(test))]
+        {
+            tokio::spawn(async move {
+                if let Err(e) = client
+                    .post(&webhook_url)
+                    .json(&payload)
+                    .timeout(Duration::from_secs(5))
+                    .send()
+                    .await
+                {
+                    error!("Failed to send webhook to {}: {}", webhook_url, e);
+                } else {
+                    debug!("Webhook to {} triggered successfully", webhook_url);
+                }
+            });
+            Ok(())
+        }
+
+        #[cfg(test)]
+        {
+            if let Err(e) = client
+                .post(&webhook_url)
+                .json(&payload)
+                .timeout(Duration::from_secs(5))
+                .send()
+                .await
+            {
+                error!("Failed to send webhook to {}: {}", webhook_url, e);
+                Err(e.into())
+            } else {
+                debug!("Webhook to {} triggered successfully", webhook_url);
+                Ok(())
+            }
+        }
+    }
+
+    pub async fn send_node_status_changed(
+        &self,
+        node: &OrchestratorNode,
+        old_status: &NodeStatus,
+    ) -> Result<(), Error> {
+        let event = WebhookEvent::NodeStatusChanged {
+            node_address: node.address.to_string(),
+            ip_address: node.ip_address.clone(),
+            port: node.port,
+            old_status: old_status.to_string(),
+            new_status: node.status.to_string(),
+        };
+
+        self.send_event(event).await
+    }
+
+    pub async fn send_group_created(
+        &self,
+        group_id: String,
+        configuration_name: String,
+        nodes: Vec<String>,
+    ) -> Result<(), Error> {
+        let event = WebhookEvent::GroupCreated {
+            group_id,
+            configuration_name,
+            nodes,
+        };
+
+        self.send_event(event).await
+    }
+
+    pub async fn send_group_destroyed(
+        &self,
+        group_id: String,
+        configuration_name: String,
+        nodes: Vec<String>,
+    ) -> Result<(), Error> {
+        let event = WebhookEvent::GroupDestroyed {
+            group_id,
+            configuration_name,
+            nodes,
+        };
+
+        self.send_event(event).await
+    }
+
+    pub async fn send_metrics_updated(
+        &self,
+        metrics: std::collections::HashMap<String, f64>,
+    ) -> Result<(), Error> {
+        let event = WebhookEvent::MetricsUpdated { metrics };
+
+        self.send_event(event).await
     }
 }
 
@@ -34,30 +206,9 @@ impl StatusUpdatePlugin for WebhookPlugin {
             return Ok(());
         }
 
-        let payload = json!({
-            "node_address": node.address.to_string(),
-            "ip_address": node.ip_address,
-            "port": node.port,
-            "old_status": old_status.to_string(),
-            "new_status": node.status.to_string(),
-            "timestamp": chrono::Utc::now().to_rfc3339(),
-        });
-
-        let webhook_url = self.webhook_url.clone();
-        let client = reqwest::Client::new();
-        tokio::spawn(async move {
-            if let Err(e) = client
-                .post(&webhook_url)
-                .json(&payload)
-                .timeout(Duration::from_secs(5))
-                .send()
-                .await
-            {
-                error!("Failed to send webhook to {}: {}", webhook_url, e);
-            } else {
-                debug!("Webhook to {} triggered successfully", webhook_url);
-            }
-        });
+        if let Err(e) = self.send_node_status_changed(node, old_status).await {
+            error!("Failed to send webhook to {}: {}", self.webhook_url, e);
+        }
 
         Ok(())
     }
@@ -67,7 +218,8 @@ impl StatusUpdatePlugin for WebhookPlugin {
 mod tests {
     use super::*;
     use alloy::primitives::Address;
-
+    use anyhow::Result;
+    use mockito::Server;
     use std::str::FromStr;
 
     fn create_test_node(status: NodeStatus) -> OrchestratorNode {
@@ -76,26 +228,128 @@ mod tests {
             ip_address: "127.0.0.1".to_string(),
             port: 8080,
             status,
-            task_id: None,
-            task_state: None,
-            version: None,
-            last_status_change: None,
-            p2p_id: Some(format!("test_p2p_id_{}", rand::random::<u64>())),
-            compute_specs: None,
+            ..Default::default()
         }
     }
 
     #[tokio::test]
-    async fn test_webhook_sends_on_status_change() {
-        let plugin = WebhookPlugin {
-            webhook_url: "https://example.com/webhook".to_string(),
-        };
+    async fn test_webhook_sends_on_status_change() -> Result<()> {
+        let mut server = Server::new_async().await;
 
+        let _mock = server
+            .mock("POST", "/webhook")
+            .with_status(200)
+            .match_body(mockito::Matcher::Json(serde_json::json!({
+                "event": "node.status_changed",
+                "data": {
+                    "node_address": "0x1234567890123456789012345678901234567890",
+                    "ip_address": "127.0.0.1",
+                    "port": 8080,
+                    "old_status": "Dead",
+                    "new_status": "Healthy"
+                },
+            })))
+            .create();
+
+        let plugin = WebhookPlugin::new(WebhookConfig {
+            url: server.url(),
+            bearer_token: None,
+        });
         let node = create_test_node(NodeStatus::Dead);
         let result = plugin
             .handle_status_change(&node, &NodeStatus::Healthy)
             .await;
-
         assert!(result.is_ok());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_webhook_sends_on_group_created() -> Result<()> {
+        let mut server = Server::new_async().await;
+        let _mock = server
+            .mock("POST", "/webhook")
+            .with_status(200)
+            .match_body(mockito::Matcher::Json(serde_json::json!({
+                "event": "group.created",
+                "data": {
+                    "group_id": "1234567890",
+                    "configuration_name": "test_configuration",
+                    "nodes": ["0x1234567890123456789012345678901234567890"]
+                }
+            })))
+            .create();
+
+        let plugin = WebhookPlugin::new(WebhookConfig {
+            url: server.url(),
+            bearer_token: None,
+        });
+        let group_id = "1234567890";
+        let configuration_name = "test_configuration";
+        let nodes = vec!["0x1234567890123456789012345678901234567890".to_string()];
+        let result = plugin
+            .send_group_created(group_id.to_string(), configuration_name.to_string(), nodes)
+            .await;
+        assert!(result.is_ok());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_webhook_sends_on_metrics_updated() -> Result<()> {
+        let mut server = Server::new_async().await;
+        let mock = server
+            .mock("POST", "/webhook")
+            .with_status(200)
+            .match_body(mockito::Matcher::Json(serde_json::json!({
+                "event": "metrics.updated",
+                "data": {
+                        "test_metric": 1.0,
+                        "metric_2": 2.0
+                },
+                "timestamp": "2024-01-01T00:00:00Z"
+            })))
+            .create();
+
+        let plugin = WebhookPlugin::new(WebhookConfig {
+            url: format!("{}/webhook", server.url()),
+            bearer_token: None,
+        });
+        let mut metrics = std::collections::HashMap::new();
+        metrics.insert("test_metric".to_string(), 1.0);
+        metrics.insert("metric_2".to_string(), 2.0);
+        let result = plugin.send_metrics_updated(metrics).await;
+        assert!(result.is_ok());
+
+        mock.assert_async().await;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_with_bearer_token() -> Result<()> {
+        let mut server = Server::new_async().await;
+        let mock = server
+            .mock("POST", "/webhook")
+            .with_status(200)
+            .match_header("Authorization", "Bearer test_token")
+            .match_body(mockito::Matcher::Json(serde_json::json!({
+                "event": "metrics.updated",
+                "data": {
+                    "metric_2": 2.0,
+                    "test_metric": 1.0
+                },
+                "timestamp": "2024-01-01T00:00:00Z"
+            })))
+            .create();
+
+        let plugin = WebhookPlugin::new(WebhookConfig {
+            url: format!("{}/webhook", server.url()),
+            bearer_token: Some("test_token".to_string()),
+        });
+        let mut metrics = std::collections::HashMap::new();
+        metrics.insert("test_metric".to_string(), 1.0);
+        metrics.insert("metric_2".to_string(), 2.0);
+        let result = plugin.send_metrics_updated(metrics).await;
+        assert!(result.is_ok());
+        mock.assert_async().await;
+        Ok(())
     }
 }

--- a/crates/orchestrator/src/store/domains/metrics_store.rs
+++ b/crates/orchestrator/src/store/domains/metrics_store.rs
@@ -150,7 +150,6 @@ impl MetricsStore {
             }
         }
 
-        println!("result {:?}", result);
         result
     }
 

--- a/crates/validator/Cargo.toml
+++ b/crates/validator/Cargo.toml
@@ -15,7 +15,6 @@ futures = { workspace = true }
 hex = { workspace = true }
 lazy_static = "1.5.0"
 log = { workspace = true }
-mockito = "1.7.0"
 nalgebra = { workspace = true }
 prometheus = "0.14.0"
 rand = "0.9.0"
@@ -32,4 +31,5 @@ toml = { workspace = true }
 url = { workspace = true }
 
 [dev-dependencies]
+mockito = { workspace = true }
 tempfile = "=3.14.0"

--- a/deployment/k8s/orchestrator-chart/templates/orchestrator-deployment.yaml
+++ b/deployment/k8s/orchestrator-chart/templates/orchestrator-deployment.yaml
@@ -60,9 +60,9 @@
       value: "{{ .root.Values.env.LOG_LEVEL }}"
     - name: HOURLY_S3_UPLOAD_LIMIT
       value: "{{ .root.Values.env.HOURLY_S3_UPLOAD_LIMIT }}"
-    {{- if .root.Values.env.WEBHOOK_URLS }}
-    - name: WEBHOOK_URLS
-      value: "{{ .root.Values.env.WEBHOOK_URLS }}"
+    {{- if .root.Values.env.WEBHOOK_CONFIGS}}
+    - name: WEBHOOK_CONFIGS
+      value: "{{ .root.Values.env.WEBHOOK_CONFIGS }}"
     {{- end }}
     {{- if .root.Values.env.NODE_GROUP_CONFIGS }}
     - name: NODE_GROUP_CONFIGS

--- a/deployment/k8s/orchestrator-chart/values.example.yaml
+++ b/deployment/k8s/orchestrator-chart/values.example.yaml
@@ -11,6 +11,7 @@ env:
   BUCKET_NAME: "your-bucket-name"
   LOG_LEVEL: "info"
   NODE_GROUP_CONFIGS: '[{"name": "h100-config", "min_group_size": 1, "max_group_size": 1, "compute_requirements": "gpu:model=h100"}, {"name": "a100-config", "min_group_size": 2, "max_group_size": 2, "compute_requirements": "gpu:model=a100"}]'
+  WEBHOOK_CONFIGS: '[{"url": "https://your-webhook-url.example.com", "bearer_token": "your-bearer-token"}]'
 secrets:
   coordinatorKey: "your-coordinator-private-key"
   adminApiKey: "your-admin-api-key"


### PR DESCRIPTION
This feature introduces a more advanced webhook plugin that automatically sends events for node status changes, groups and metrics. Metrics are simply sent periodically if changes on the aggregated metrics are detected. 

For testing I've simply used `https://webhook.site`, added this to my env: `WEBHOOK_CONFIGS='[{"url": "https://webhook.site/<your code>}]'` and started the setup using `make up`. After adding a worker I can see events pop in. To test the metrics I simply used the bridge in the /examples folder. Make sure to create a task & adjust the task_id. 

Event Examples:
```
{
  "event": "metrics.updated",
  "data": {
    "gpu_0_utilization": 67,
    "gpu_3_memory_total": 85899345920,
    "gpu_2_memory_used": 76715130880,
    "gpu_3_utilization": 91,
    "memory_usage": 1432368,
  },
  "timestamp": "2025-06-03T12:45:39.736102+00:00"
}
```

```
{
  "event": "group.created",
  "data": {
    "group_id": "9800b94fbf6e1764",
    "configuration_name": "test-config",
    "nodes": [
      "0x66295E2B4A78d1Cb57Db16Ac0260024900A5BA9B"
    ]
  },
  "timestamp": "2025-06-03T12:36:27.813610+00:00"
}
```

```
{
  "event": "group.destroyed",
  "data": {
    "group_id": "c96f76a7341817f3",
    "configuration_name": "test-config",
    "nodes": [
      "0x66295E2B4A78d1Cb57Db16Ac0260024900A5BA9B"
    ]
  },
  "timestamp": "2025-06-03T12:31:07.252373+00:00"
}
```

```
{
  "event": "node.status_changed",
  "data": {
    "node_address": "0x66295E2B4A78d1Cb57Db16Ac0260024900A5BA9B",
    "ip_address": "localhost",
    "port": 8091,
    "old_status": "Dead",
    "new_status": "Healthy"
  },
  "timestamp": "2025-06-03T12:34:18.513022+00:00"
}
```