### PR TITLE
feat(orchestrator): add first_seen timestamp to track node discovery …

### DIFF
--- a/crates/orchestrator/src/api/routes/nodes.rs
+++ b/crates/orchestrator/src/api/routes/nodes.rs
@@ -469,6 +469,7 @@ mod tests {
             version: None,
             last_status_change: None,
             p2p_id: None,
+            first_seen: None,
             compute_specs: None,
         };
         app_state

--- a/crates/orchestrator/src/discovery/monitor.rs
+++ b/crates/orchestrator/src/discovery/monitor.rs
@@ -5,6 +5,7 @@ use crate::utils::loop_heartbeats::LoopHeartbeats;
 use alloy::primitives::Address;
 use anyhow::Error;
 use anyhow::Result;
+use chrono;
 use log::{error, info};
 use serde_json;
 use shared::models::api::ApiResponse;
@@ -14,7 +15,6 @@ use shared::web3::wallet::Wallet;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::time::interval;
-use chrono;
 
 pub struct DiscoveryMonitor {
     coordinator_wallet: Wallet,
@@ -439,22 +439,22 @@ mod tests {
 
         assert!(node_from_store.is_some());
         let node = node_from_store.unwrap();
-        
+
         // Verify first_seen is set
         assert!(node.first_seen.is_some());
         let first_seen = node.first_seen.unwrap();
-        
+
         // Verify the timestamp is within the expected range
         assert!(first_seen >= time_before && first_seen <= time_after);
-        
+
         // Verify other fields are set correctly
         assert_eq!(node.status, NodeStatus::Discovered);
         assert_eq!(node.ip_address, "192.168.1.100");
-        
+
         // Test case: Sync the same node again to verify first_seen is preserved
         // Simulate some time passing
         tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
-        
+
         // Update discovery data to simulate a change (e.g., IP address change)
         let updated_discovery_node = DiscoveryNode {
             is_validated: true,
@@ -472,13 +472,13 @@ mod tests {
             last_updated: Some(chrono::Utc::now()),
             created_at: None,
         };
-        
+
         // Sync the node again
         discovery_monitor
             .sync_single_node_with_discovery(&updated_discovery_node)
             .await
             .unwrap();
-        
+
         // Verify the node was updated but first_seen is preserved
         let node_after_resync = store_context
             .node_store
@@ -486,13 +486,13 @@ mod tests {
             .await
             .unwrap()
             .unwrap();
-        
+
         // Verify first_seen is still the same (preserved)
         assert_eq!(node_after_resync.first_seen, Some(first_seen));
-        
+
         // Verify IP was updated
         assert_eq!(node_after_resync.ip_address, "192.168.1.101");
-        
+
         // Status should remain the same
         assert_eq!(node_after_resync.status, NodeStatus::Discovered);
     }

--- a/crates/orchestrator/src/models/node.rs
+++ b/crates/orchestrator/src/models/node.rs
@@ -18,6 +18,7 @@ pub struct OrchestratorNode {
     pub version: Option<String>,
     pub p2p_id: Option<String>,
     pub last_status_change: Option<DateTime<Utc>>,
+    pub first_seen: Option<DateTime<Utc>>,
 
     #[serde(default)]
     pub compute_specs: Option<ComputeSpecs>,
@@ -42,6 +43,7 @@ impl From<DiscoveryNode> for OrchestratorNode {
             version: None,
             p2p_id: None,
             last_status_change: None,
+            first_seen: None,
             compute_specs: discovery_node.compute_specs.clone(),
         }
     }

--- a/crates/orchestrator/src/plugins/node_groups/tests.rs
+++ b/crates/orchestrator/src/plugins/node_groups/tests.rs
@@ -40,6 +40,7 @@ fn create_test_node(
         task_state: None,
         version: None,
         last_status_change: None,
+        first_seen: None,
         p2p_id: Some("test_p2p_id".to_string()),
         compute_specs,
     }

--- a/crates/orchestrator/src/status_update/mod.rs
+++ b/crates/orchestrator/src/status_update/mod.rs
@@ -368,6 +368,7 @@ mod tests {
             version: None,
             last_status_change: None,
             p2p_id: None,
+            first_seen: None,
             compute_specs: None,
         };
 
@@ -449,6 +450,7 @@ mod tests {
             version: None,
             last_status_change: None,
             p2p_id: None,
+            first_seen: None,
             compute_specs: None,
         };
 
@@ -507,6 +509,7 @@ mod tests {
             version: None,
             last_status_change: None,
             p2p_id: None,
+            first_seen: None,
             compute_specs: None,
         };
 
@@ -572,6 +575,7 @@ mod tests {
             version: None,
             last_status_change: None,
             p2p_id: None,
+            first_seen: None,
             compute_specs: None,
         };
 
@@ -642,6 +646,7 @@ mod tests {
             version: None,
             last_status_change: None,
             p2p_id: None,
+            first_seen: None,
             compute_specs: None,
         };
         if let Err(e) = app_state
@@ -735,6 +740,7 @@ mod tests {
             version: None,
             last_status_change: None,
             p2p_id: None,
+            first_seen: None,
             compute_specs: None,
         };
         if let Err(e) = app_state
@@ -764,6 +770,7 @@ mod tests {
             version: None,
             last_status_change: None,
             p2p_id: None,
+            first_seen: None,
             compute_specs: None,
         };
 
@@ -845,6 +852,7 @@ mod tests {
             version: None,
             last_status_change: None,
             p2p_id: None,
+            first_seen: None,
             compute_specs: None,
         };
 
@@ -940,6 +948,7 @@ mod tests {
             version: None,
             last_status_change: None,
             p2p_id: None,
+            first_seen: None,
             compute_specs: None,
         };
 

--- a/crates/orchestrator/src/store/domains/node_store.rs
+++ b/crates/orchestrator/src/store/domains/node_store.rs
@@ -198,6 +198,7 @@ mod tests {
             version: None,
             last_status_change: None,
             p2p_id: None,
+            first_seen: None,
             compute_specs: None,
         };
 
@@ -211,6 +212,7 @@ mod tests {
             version: None,
             last_status_change: None,
             p2p_id: None,
+            first_seen: None,
             compute_specs: None,
         };
 
@@ -238,6 +240,7 @@ mod tests {
                 version: None,
                 p2p_id: None,
                 last_status_change: None,
+                first_seen: None,
                 compute_specs: None,
             },
             OrchestratorNode {
@@ -250,6 +253,7 @@ mod tests {
                 version: None,
                 p2p_id: None,
                 last_status_change: None,
+                first_seen: None,
                 compute_specs: None,
             },
             OrchestratorNode {
@@ -262,6 +266,7 @@ mod tests {
                 version: None,
                 p2p_id: None,
                 last_status_change: None,
+                first_seen: None,
                 compute_specs: None,
             },
         ];


### PR DESCRIPTION
…time

- Add `first_seen` field to `OrchestratorNode` struct to track when a node was first seen on the orchestrator
- Set timestamp when a new node is synced from discovery service
- Preserve first_seen timestamp during node updates
- Add tests to verify timestamp is set on discovery and preserved on updates

Closes #409  