### PR TITLE
add additional prometheus operator metrics, add taskname to node metrics

### DIFF
--- a/crates/orchestrator/src/api/routes/storage.rs
+++ b/crates/orchestrator/src/api/routes/storage.rs
@@ -274,6 +274,12 @@ async fn request_upload(
                 file_name
             );
 
+            app_state.metrics.increment_file_upload_requests(
+                &request_upload.task_id,
+                &task.name,
+                address,
+            );
+
             #[cfg(test)]
             return HttpResponse::Ok().json(serde_json::json!({
                 "success": true,
@@ -380,6 +386,11 @@ mod tests {
             json["file_name"],
             serde_json::Value::String("model_123/user_uploads/test.parquet".to_string())
         );
+
+        let metrics = app_state.metrics.export_metrics().unwrap();
+        println!("{}", metrics);
+        assert!(metrics.contains("orchestrator_file_upload_requests_total"));
+        assert!(metrics.contains(&format!("orchestrator_file_upload_requests_total{{node_address=\"test_address\",pool_id=\"{}\",task_id=\"{}\",task_name=\"test-task\"}} 1", app_state.metrics.pool_id, task.id)));
     }
 
     #[actix_web::test]

--- a/crates/orchestrator/src/api/routes/storage.rs
+++ b/crates/orchestrator/src/api/routes/storage.rs
@@ -388,7 +388,6 @@ mod tests {
         );
 
         let metrics = app_state.metrics.export_metrics().unwrap();
-        println!("{}", metrics);
         assert!(metrics.contains("orchestrator_file_upload_requests_total"));
         assert!(metrics.contains(&format!("orchestrator_file_upload_requests_total{{node_address=\"test_address\",pool_id=\"{}\",task_id=\"{}\",task_name=\"test-task\"}} 1", app_state.metrics.pool_id, task.id)));
     }

--- a/crates/orchestrator/src/main.rs
+++ b/crates/orchestrator/src/main.rs
@@ -272,12 +272,14 @@ async fn main() -> Result<()> {
         // Start metrics sync service to centralize metrics from Redis to Prometheus
         let metrics_sync_store_context = store_context.clone();
         let metrics_sync_context = metrics_context.clone();
+        let metrics_sync_node_groups = node_groups_plugin.clone();
         tasks.spawn(async move {
             let sync_service = MetricsSyncService::new(
                 metrics_sync_store_context,
                 metrics_sync_context,
                 server_mode,
                 10,
+                metrics_sync_node_groups,
             );
             sync_service.run().await
         });
@@ -328,8 +330,6 @@ async fn main() -> Result<()> {
 
         let status_update_store_context = store_context.clone();
         let status_update_heartbeats = heartbeats.clone();
-        let status_update_metrics = metrics_context.clone();
-
         tasks.spawn({
             let contracts = contracts.clone();
             async move {
@@ -342,7 +342,6 @@ async fn main() -> Result<()> {
                     args.disable_ejection,
                     status_update_heartbeats.clone(),
                     status_update_plugins,
-                    status_update_metrics,
                 );
                 status_updater.run().await
             }

--- a/crates/orchestrator/src/metrics/mod.rs
+++ b/crates/orchestrator/src/metrics/mod.rs
@@ -1,4 +1,4 @@
-use prometheus::{GaugeVec, Opts, Registry, TextEncoder};
+use prometheus::{CounterVec, GaugeVec, Opts, Registry, TextEncoder};
 pub mod sync_service;
 pub mod webhook_sender;
 
@@ -6,6 +6,12 @@ pub struct MetricsContext {
     pub compute_task_gauges: GaugeVec,
     pub pool_id: String,
     pub registry: Registry,
+    pub file_upload_requests_total: CounterVec,
+    pub nodes_total: GaugeVec,
+    pub tasks_total: GaugeVec,
+    pub groups_total: GaugeVec,
+    pub heartbeat_requests_total: CounterVec,
+    pub nodes_per_task: GaugeVec,
 }
 
 impl MetricsContext {
@@ -13,16 +19,81 @@ impl MetricsContext {
         // For current state/rate metrics
         let compute_task_gauges = GaugeVec::new(
             Opts::new("compute_gauges", "Compute task gauge metrics"),
-            &["node_address", "task_id", "label", "pool_id"],
+            &["node_address", "task_id", "task_name", "label", "pool_id"],
         )
         .unwrap();
+
+        // New metrics for orchestrator statistics
+        let file_upload_requests_total = CounterVec::new(
+            Opts::new(
+                "orchestrator_file_upload_requests_total",
+                "Total number of file upload requests",
+            ),
+            &["task_id", "task_name", "node_address", "pool_id"],
+        )
+        .unwrap();
+
+        let nodes_total = GaugeVec::new(
+            Opts::new(
+                "orchestrator_nodes_total",
+                "Total number of nodes by status",
+            ),
+            &["status", "pool_id"],
+        )
+        .unwrap();
+
+        let tasks_total = GaugeVec::new(
+            Opts::new("orchestrator_tasks_total", "Total number of tasks"),
+            &["pool_id"],
+        )
+        .unwrap();
+
+        let groups_total = GaugeVec::new(
+            Opts::new(
+                "orchestrator_groups_total",
+                "Total number of node groups by configuration",
+            ),
+            &["configuration_name", "pool_id"],
+        )
+        .unwrap();
+
+        let heartbeat_requests_total = CounterVec::new(
+            Opts::new(
+                "orchestrator_heartbeat_requests_total",
+                "Total number of heartbeat requests per node",
+            ),
+            &["node_address", "pool_id"],
+        )
+        .unwrap();
+
+        let nodes_per_task = GaugeVec::new(
+            Opts::new(
+                "orchestrator_nodes_per_task",
+                "Number of nodes actively working on each task",
+            ),
+            &["task_id", "task_name", "pool_id"],
+        )
+        .unwrap();
+
         let registry = Registry::new();
         let _ = registry.register(Box::new(compute_task_gauges.clone()));
+        let _ = registry.register(Box::new(file_upload_requests_total.clone()));
+        let _ = registry.register(Box::new(nodes_total.clone()));
+        let _ = registry.register(Box::new(tasks_total.clone()));
+        let _ = registry.register(Box::new(groups_total.clone()));
+        let _ = registry.register(Box::new(heartbeat_requests_total.clone()));
+        let _ = registry.register(Box::new(nodes_per_task.clone()));
 
         Self {
             compute_task_gauges,
             pool_id,
             registry,
+            file_upload_requests_total,
+            nodes_total,
+            tasks_total,
+            groups_total,
+            heartbeat_requests_total,
+            nodes_per_task,
         }
     }
 
@@ -30,23 +101,54 @@ impl MetricsContext {
         &self,
         node_address: &str,
         task_id: &str,
+        task_name: &str,
         label: &str,
         value: f64,
     ) {
         self.compute_task_gauges
-            .with_label_values(&[node_address, task_id, label, &self.pool_id])
+            .with_label_values(&[node_address, task_id, task_name, label, &self.pool_id])
             .set(value);
     }
 
-    pub fn remove_compute_task_gauge(&self, node_address: &str, task_id: &str, label: &str) {
-        if let Err(e) = self.compute_task_gauges.remove_label_values(&[
-            node_address,
-            task_id,
-            label,
-            &self.pool_id,
-        ]) {
-            println!("Error removing compute task gauge: {}", e);
-        }
+    pub fn increment_file_upload_requests(
+        &self,
+        task_id: &str,
+        task_name: &str,
+        node_address: &str,
+    ) {
+        self.file_upload_requests_total
+            .with_label_values(&[task_id, task_name, node_address, &self.pool_id])
+            .inc();
+    }
+
+    pub fn increment_heartbeat_requests(&self, node_address: &str) {
+        self.heartbeat_requests_total
+            .with_label_values(&[node_address, &self.pool_id])
+            .inc();
+    }
+
+    pub fn set_nodes_count(&self, status: &str, count: f64) {
+        self.nodes_total
+            .with_label_values(&[status, &self.pool_id])
+            .set(count);
+    }
+
+    pub fn set_tasks_count(&self, count: f64) {
+        self.tasks_total
+            .with_label_values(&[&self.pool_id])
+            .set(count);
+    }
+
+    pub fn set_groups_count(&self, configuration_name: &str, count: f64) {
+        self.groups_total
+            .with_label_values(&[configuration_name, &self.pool_id])
+            .set(count);
+    }
+
+    pub fn set_nodes_per_task(&self, task_id: &str, task_name: &str, count: f64) {
+        self.nodes_per_task
+            .with_label_values(&[task_id, task_name, &self.pool_id])
+            .set(count);
     }
 
     pub fn export_metrics(&self) -> Result<String, prometheus::Error> {
@@ -60,5 +162,13 @@ impl MetricsContext {
         // Clear all time series from the compute_task_gauges metric family
         // This removes all existing metrics so we can rebuild from Redis
         self.compute_task_gauges.reset();
+    }
+
+    /// Clear all orchestrator statistics metrics
+    pub fn clear_orchestrator_statistics(&self) {
+        self.nodes_total.reset();
+        self.tasks_total.reset();
+        self.groups_total.reset();
+        self.nodes_per_task.reset();
     }
 }

--- a/crates/orchestrator/src/metrics/sync_service.rs
+++ b/crates/orchestrator/src/metrics/sync_service.rs
@@ -1,7 +1,9 @@
 use crate::metrics::MetricsContext;
+use crate::plugins::node_groups::NodeGroupsPlugin;
 use crate::store::core::StoreContext;
 use crate::ServerMode;
 use log::{debug, error, info};
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::time::interval;
@@ -11,6 +13,7 @@ pub struct MetricsSyncService {
     metrics_context: Arc<MetricsContext>,
     server_mode: ServerMode,
     sync_interval: Duration,
+    node_groups_plugin: Option<Arc<NodeGroupsPlugin>>,
 }
 
 impl MetricsSyncService {
@@ -19,12 +22,14 @@ impl MetricsSyncService {
         metrics_context: Arc<MetricsContext>,
         server_mode: ServerMode,
         sync_interval_seconds: u64,
+        node_groups_plugin: Option<Arc<NodeGroupsPlugin>>,
     ) -> Self {
         Self {
             store_context,
             metrics_context,
             server_mode,
             sync_interval: Duration::from_secs(sync_interval_seconds),
+            node_groups_plugin,
         }
     }
 
@@ -49,6 +54,9 @@ impl MetricsSyncService {
             if let Err(e) = self.sync_metrics_from_redis().await {
                 error!("Error syncing metrics from Redis: {}", e);
             }
+            if let Err(e) = self.sync_orchestrator_statistics().await {
+                error!("Error syncing orchestrator statistics: {}", e);
+            }
         }
     }
 
@@ -64,17 +72,38 @@ impl MetricsSyncService {
             }
         };
 
+        // Get all tasks to map task_id to task_name
+        let tasks = self
+            .store_context
+            .task_store
+            .get_all_tasks()
+            .await
+            .unwrap_or_else(|e| {
+                error!("Failed to get tasks for task name mapping: {}", e);
+                Vec::new()
+            });
+        let task_name_map: HashMap<String, String> = tasks
+            .into_iter()
+            .map(|task| (task.id.to_string(), task.name.clone()))
+            .collect();
+
         // Clear existing Prometheus metrics
         self.metrics_context.clear_compute_task_metrics();
 
         // Rebuild metrics from Redis data
         let mut total_metrics = 0;
         for (task_id, task_metrics) in redis_metrics {
+            let task_name = task_name_map.get(&task_id).cloned().unwrap_or_else(|| {
+                debug!("No task name found for task_id: {}", task_id);
+                "unknown".to_string()
+            });
+
             for (label, node_metrics) in task_metrics {
                 for (node_address, value) in node_metrics {
                     self.metrics_context.record_compute_task_gauge(
                         &node_address,
                         &task_id,
+                        &task_name,
                         &label,
                         value,
                     );
@@ -87,6 +116,93 @@ impl MetricsSyncService {
             "Synced {} metric entries from Redis to Prometheus",
             total_metrics
         );
+        Ok(())
+    }
+
+    pub async fn sync_orchestrator_statistics(&self) -> anyhow::Result<()> {
+        debug!("Syncing orchestrator statistics to Prometheus");
+
+        // Clear existing orchestrator statistics
+        self.metrics_context.clear_orchestrator_statistics();
+
+        // Sync nodes count by status
+        if let Ok(nodes) = self.store_context.node_store.get_nodes().await {
+            let mut status_counts: HashMap<String, i32> = HashMap::new();
+            for node in nodes {
+                let status = format!("{:?}", node.status).to_lowercase();
+                *status_counts.entry(status).or_insert(0) += 1;
+            }
+            for (status, count) in status_counts {
+                self.metrics_context.set_nodes_count(&status, count as f64);
+            }
+            debug!("Synced node statistics");
+        } else {
+            error!("Failed to get nodes for statistics");
+        }
+
+        // Sync total tasks count (simple count, not by state)
+        if let Ok(tasks) = self.store_context.task_store.get_all_tasks().await {
+            let total_tasks = tasks.len() as f64;
+            self.metrics_context.set_tasks_count(total_tasks);
+            debug!("Synced task statistics: {} total tasks", total_tasks);
+        } else {
+            error!("Failed to get tasks for statistics");
+        }
+
+        // Sync nodes per task based on node assignments
+        if let Ok(nodes) = self.store_context.node_store.get_nodes().await {
+            if let Ok(tasks) = self.store_context.task_store.get_all_tasks().await {
+                // Create task name mapping
+                let task_name_map: HashMap<String, String> = tasks
+                    .into_iter()
+                    .map(|task| (task.id.to_string(), task.name.clone()))
+                    .collect();
+
+                // Count nodes per task
+                let mut task_node_counts: HashMap<String, i32> = HashMap::new();
+                for node in nodes {
+                    if let Some(task_id) = &node.task_id {
+                        *task_node_counts.entry(task_id.clone()).or_insert(0) += 1;
+                    }
+                }
+
+                // Set metrics for each task with active nodes
+                for (task_id, count) in task_node_counts {
+                    let task_name = task_name_map.get(&task_id).cloned().unwrap_or_else(|| {
+                        debug!("No task name found for task_id: {}", task_id);
+                        "unknown".to_string()
+                    });
+                    self.metrics_context
+                        .set_nodes_per_task(&task_id, &task_name, count as f64);
+                }
+                debug!("Synced nodes per task statistics");
+            } else {
+                error!("Failed to get tasks for nodes per task statistics");
+            }
+        } else {
+            error!("Failed to get nodes for nodes per task statistics");
+        }
+
+        // Sync groups count by configuration name
+        if let Some(node_groups_plugin) = &self.node_groups_plugin {
+            if let Ok(groups) = node_groups_plugin.get_all_groups().await {
+                let mut config_counts: HashMap<String, i32> = HashMap::new();
+                for group in groups {
+                    *config_counts.entry(group.configuration_name).or_insert(0) += 1;
+                }
+                for (config_name, count) in config_counts {
+                    self.metrics_context
+                        .set_groups_count(&config_name, count as f64);
+                }
+                debug!("Synced group statistics");
+            } else {
+                error!("Failed to get groups for statistics");
+            }
+        } else {
+            debug!("Node groups plugin not available, skipping groups metrics");
+        }
+
+        debug!("Completed syncing orchestrator statistics");
         Ok(())
     }
 }

--- a/crates/orchestrator/src/status_update/mod.rs
+++ b/crates/orchestrator/src/status_update/mod.rs
@@ -1,4 +1,3 @@
-use crate::metrics::MetricsContext;
 use crate::models::node::{NodeStatus, OrchestratorNode};
 use crate::plugins::StatusUpdatePlugin;
 use crate::store::core::StoreContext;
@@ -20,7 +19,6 @@ pub struct NodeStatusUpdater {
     disable_ejection: bool,
     heartbeats: Arc<LoopHeartbeats>,
     plugins: Vec<Box<dyn StatusUpdatePlugin>>,
-    metrics_context: Arc<MetricsContext>,
 }
 
 impl NodeStatusUpdater {
@@ -34,7 +32,6 @@ impl NodeStatusUpdater {
         disable_ejection: bool,
         heartbeats: Arc<LoopHeartbeats>,
         plugins: Vec<Box<dyn StatusUpdatePlugin>>,
-        metrics_context: Arc<MetricsContext>,
     ) -> Self {
         Self {
             store_context,
@@ -45,7 +42,6 @@ impl NodeStatusUpdater {
             disable_ejection,
             heartbeats,
             plugins,
-            metrics_context,
         }
     }
 
@@ -279,12 +275,6 @@ impl NodeStatusUpdater {
 
                     for (task_id, task_metrics) in node_metrics {
                         for (label, _value) in task_metrics {
-                            // Remove from Prometheus metrics
-                            self.metrics_context.remove_compute_task_gauge(
-                                &node.address.to_string(),
-                                &task_id,
-                                &label,
-                            );
                             // Remove from Redis metrics store
                             if let Err(e) = self
                                 .store_context
@@ -356,7 +346,6 @@ mod tests {
             false,
             Arc::new(LoopHeartbeats::new(&mode)),
             vec![],
-            app_state.metrics.clone(),
         );
         let node = OrchestratorNode {
             address: Address::from_str("0x0000000000000000000000000000000000000000").unwrap(),
@@ -470,7 +459,6 @@ mod tests {
             false,
             Arc::new(LoopHeartbeats::new(&mode)),
             vec![],
-            app_state.metrics.clone(),
         );
         tokio::spawn(async move {
             updater
@@ -528,7 +516,6 @@ mod tests {
             false,
             Arc::new(LoopHeartbeats::new(&mode)),
             vec![],
-            app_state.metrics.clone(),
         );
         tokio::spawn(async move {
             updater
@@ -602,7 +589,6 @@ mod tests {
             false,
             Arc::new(LoopHeartbeats::new(&mode)),
             vec![],
-            app_state.metrics.clone(),
         );
         tokio::spawn(async move {
             updater
@@ -689,7 +675,6 @@ mod tests {
             false,
             Arc::new(LoopHeartbeats::new(&mode)),
             vec![],
-            app_state.metrics.clone(),
         );
         tokio::spawn(async move {
             updater
@@ -786,7 +771,6 @@ mod tests {
             false,
             Arc::new(LoopHeartbeats::new(&mode)),
             vec![],
-            app_state.metrics.clone(),
         );
         tokio::spawn(async move {
             updater
@@ -875,7 +859,6 @@ mod tests {
             false,
             Arc::new(LoopHeartbeats::new(&mode)),
             vec![],
-            app_state.metrics.clone(),
         );
         tokio::spawn(async move {
             updater
@@ -961,7 +944,6 @@ mod tests {
             false,
             Arc::new(LoopHeartbeats::new(&mode)),
             vec![],
-            app_state.metrics.clone(),
         );
         tokio::spawn(async move {
             updater
@@ -1030,7 +1012,6 @@ mod tests {
             false,
             Arc::new(LoopHeartbeats::new(&mode)),
             vec![],
-            app_state.metrics.clone(),
         );
         tokio::spawn(async move {
             updater


### PR DESCRIPTION
- adds additional metrics to orchestrator operations (e.g. file upload count, tasks, nodes in different states etc.) 
- adds file name to task metrics that are sent by remote nodes
fixes #411