### PR TITLE
Include exact version tag in dev-release

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -31,6 +31,8 @@ jobs:
 
       # Use all available cores for the build
       - name: Build all workspace members
+        env:
+          WORKER_VERSION: ${{ steps.next_version.outputs.tag_name }}
         run: |
           export CARGO_BUILD_JOBS=$(nproc)
           cargo build --release --workspace

--- a/crates/worker/build.rs
+++ b/crates/worker/build.rs
@@ -1,0 +1,7 @@
+fn main() {
+    // If WORKER_VERSION is set during the build (e.g., in CI),
+    // pass it to the rustc compiler.
+    if let Ok(version) = std::env::var("WORKER_VERSION") {
+        println!("cargo:rustc-env=WORKER_VERSION={}", version);
+    }
+}

--- a/crates/worker/src/cli/command.rs
+++ b/crates/worker/src/cli/command.rs
@@ -211,7 +211,7 @@ pub async fn execute_command(
             };
 
             let mut recover_last_state = *auto_recover;
-            let version = env!("CARGO_PKG_VERSION");
+            let version = option_env!("WORKER_VERSION").unwrap_or(env!("CARGO_PKG_VERSION"));
             Console::section("🚀 PRIME WORKER INITIALIZATION - beta");
             Console::info("Version", version);
             /*

--- a/crates/worker/src/operations/heartbeat/service.rs
+++ b/crates/worker/src/operations/heartbeat/service.rs
@@ -163,7 +163,11 @@ async fn send_heartbeat(
             task_id: Some(task.id.to_string()),
             task_state: Some(task.state.to_string()),
             metrics: Some(metrics_for_task),
-            version: Some(env!("CARGO_PKG_VERSION").to_string()),
+            version: Some(
+                option_env!("WORKER_VERSION")
+                    .unwrap_or(env!("CARGO_PKG_VERSION"))
+                    .to_string(),
+            ),
             timestamp: Some(ts),
             p2p_id,
         }
@@ -173,7 +177,11 @@ async fn send_heartbeat(
             task_id: None,
             task_state: None,
             metrics: None,
-            version: Some(env!("CARGO_PKG_VERSION").to_string()),
+            version: Some(
+                option_env!("WORKER_VERSION")
+                    .unwrap_or(env!("CARGO_PKG_VERSION"))
+                    .to_string(),
+            ),
             timestamp: Some(ts),
             p2p_id,
         }


### PR DESCRIPTION
Currently in dev releases the wrong worker version is reported which makes large scale integration tests hard. 