### PR TITLE
fix(worker): Use correct version for `prime worker --version` on develop builds

### DIFF
--- a/crates/worker/src/cli/command.rs
+++ b/crates/worker/src/cli/command.rs
@@ -32,8 +32,13 @@ use tokio::sync::RwLock;
 use tokio_util::sync::CancellationToken;
 use url::Url;
 
+const APP_VERSION: &str = match option_env!("WORKER_VERSION") {
+    Some(version) => version,
+    None => env!("CARGO_PKG_VERSION"),
+};
+
 #[derive(Parser)]
-#[command(author, version, about, long_about = None)]
+#[command(author, version = APP_VERSION, about, long_about = None)]
 pub struct Cli {
     #[command(subcommand)]
     pub command: Commands,
@@ -216,7 +221,7 @@ pub async fn execute_command(
             };
 
             let mut recover_last_state = !(*no_auto_recover);
-            let version = option_env!("WORKER_VERSION").unwrap_or(env!("CARGO_PKG_VERSION"));
+            let version = APP_VERSION;
             Console::section("🚀 PRIME WORKER INITIALIZATION - beta");
             Console::info("Version", version);
             /*


### PR DESCRIPTION
## Context
This PR addresses https://github.com/PrimeIntellect-ai/protocol/issues/494

## Implementation
- The CLI `--version` flag was using clap's default version (i.e. `CARGO_PKG_VERSION`)
- This fix adds a check to first get `WORKER_VERSION` if it exists, and falls back to `CARGO_PKG_VERSION` if it doesn't, just like in the heartbeat service.