### PR TITLE
refactor: remove unused async from functions

### DIFF
--- a/crates/dev-utils/examples/submit_work.rs
+++ b/crates/dev-utils/examples/submit_work.rs
@@ -54,7 +54,6 @@ async fn main() -> Result<()> {
     let call = contracts
         .compute_pool
         .build_work_submission_call(pool_id, node, work_key, U256::from(179949060096000.0))
-        .await
         .map_err(|e| eyre::eyre!("Failed to build work submission call: {}", e))?;
 
     let tx = call

--- a/crates/discovery/src/chainsync/sync.rs
+++ b/crates/discovery/src/chainsync/sync.rs
@@ -121,7 +121,7 @@ impl ChainSync {
         }
     }
 
-    pub async fn run(self) -> Result<(), Error> {
+    pub fn run(self) -> Result<(), Error> {
         let ChainSync {
             node_store,
             cancel_token,

--- a/crates/discovery/src/main.rs
+++ b/crates/discovery/src/main.rs
@@ -119,7 +119,7 @@ async fn main() -> Result<()> {
                 contracts.clone(),
                 last_chain_sync.clone(),
             );
-            chain_sync.run().await?;
+            chain_sync.run()?;
 
             // Start location enrichment service if enabled
             if let Some(location_url) = args.location_service_url.clone() {

--- a/crates/orchestrator/src/metrics/webhook_sender.rs
+++ b/crates/orchestrator/src/metrics/webhook_sender.rs
@@ -70,17 +70,7 @@ impl MetricsWebhookSender {
             if Self::metrics_changed(&metrics, &self.last_sent_metrics) {
                 info!("Sending {} metrics via webhook", metrics.len());
                 for plugin in &self.webhook_plugins {
-                    #[cfg(test)]
-                    {
-                        let _ = plugin
-                            .send_metrics_updated(self.pool_id, metrics.clone())
-                            .await;
-                    }
-                    #[cfg(not(test))]
-                    {
-                        let _ = plugin
-                            .send_metrics_updated(self.pool_id, metrics.clone());
-                    }
+                    let _ = plugin.send_metrics_updated(self.pool_id, metrics.clone());
                 }
                 // Update last sent metrics
                 self.last_sent_metrics = metrics.clone();

--- a/crates/orchestrator/src/metrics/webhook_sender.rs
+++ b/crates/orchestrator/src/metrics/webhook_sender.rs
@@ -70,9 +70,17 @@ impl MetricsWebhookSender {
             if Self::metrics_changed(&metrics, &self.last_sent_metrics) {
                 info!("Sending {} metrics via webhook", metrics.len());
                 for plugin in &self.webhook_plugins {
-                    let _ = plugin
-                        .send_metrics_updated(self.pool_id, metrics.clone())
-                        .await;
+                    #[cfg(test)]
+                    {
+                        let _ = plugin
+                            .send_metrics_updated(self.pool_id, metrics.clone())
+                            .await;
+                    }
+                    #[cfg(not(test))]
+                    {
+                        let _ = plugin
+                            .send_metrics_updated(self.pool_id, metrics.clone());
+                    }
                 }
                 // Update last sent metrics
                 self.last_sent_metrics = metrics.clone();

--- a/crates/orchestrator/src/plugins/node_groups/mod.rs
+++ b/crates/orchestrator/src/plugins/node_groups/mod.rs
@@ -622,17 +622,13 @@ impl NodeGroupsPlugin {
         for group in webhook_groups {
             if let Some(plugins) = &self.webhook_plugins {
                 for plugin in plugins.iter() {
-                    let group_clone = group.clone();
-                    let plugin_clone = plugin.clone();
-                    tokio::spawn(async move {
-                        if let Err(e) = plugin_clone.send_group_created(
-                            group_clone.id.to_string(),
-                            group_clone.configuration_name.to_string(),
-                            group_clone.nodes.iter().cloned().collect(),
-                        ) {
-                            error!("Failed to send group created webhook: {}", e);
-                        }
-                    });
+                    if let Err(e) = plugin.send_group_created(
+                        group.id.clone(),
+                        group.configuration_name.clone(),
+                        group.nodes.iter().cloned().collect(),
+                    ) {
+                        error!("Failed to send group created webhook: {}", e);
+                    }
                 }
             }
         }
@@ -989,33 +985,25 @@ impl NodeGroupsPlugin {
             // Send dissolved notifications
             for group in dissolved_groups {
                 for plugin in plugins.iter() {
-                    let plugin_clone = plugin.clone();
-                    let group_clone = group.clone();
-                    tokio::spawn(async move {
-                        if let Err(e) = plugin_clone.send_group_destroyed(
-                            group_clone.id,
-                            group_clone.configuration_name,
-                            group_clone.nodes.iter().cloned().collect(),
-                        ) {
-                            error!("Failed to send group dissolved webhook: {}", e);
-                        }
-                    });
+                    if let Err(e) = plugin.send_group_destroyed(
+                        group.id.clone(),
+                        group.configuration_name.clone(),
+                        group.nodes.iter().cloned().collect(),
+                    ) {
+                        error!("Failed to send group dissolved webhook: {}", e);
+                    }
                 }
             }
 
             // Send created notification
             for plugin in plugins.iter() {
-                let plugin_clone = plugin.clone();
-                let group_clone = merged_group.clone();
-                tokio::spawn(async move {
-                    if let Err(e) = plugin_clone.send_group_created(
-                        group_clone.id,
-                        group_clone.configuration_name,
-                        group_clone.nodes.iter().cloned().collect(),
-                    ) {
-                        error!("Failed to send group created webhook: {}", e);
-                    }
-                });
+                if let Err(e) = plugin.send_group_created(
+                    merged_group.id.clone(),
+                    merged_group.configuration_name.clone(),
+                    merged_group.nodes.iter().cloned().collect(),
+                ) {
+                    error!("Failed to send group created webhook: {}", e);
+                }
             }
         }
     }
@@ -1088,17 +1076,13 @@ impl NodeGroupsPlugin {
             );
             if let Some(plugins) = &self.webhook_plugins {
                 for plugin in plugins.iter() {
-                    let plugin_clone = plugin.clone();
-                    let group_clone = group.clone();
-                    tokio::spawn(async move {
-                        if let Err(e) = plugin_clone.send_group_destroyed(
-                            group_clone.id.to_string(),
-                            group_clone.configuration_name.to_string(),
-                            group_clone.nodes.iter().cloned().collect(),
-                        ) {
-                            error!("Failed to send group dissolved webhook: {}", e);
-                        }
-                    });
+                    if let Err(e) = plugin.send_group_destroyed(
+                        group.id.clone(),
+                        group.configuration_name.clone(),
+                        group.nodes.iter().cloned().collect(),
+                    ) {
+                        error!("Failed to send group dissolved webhook: {}", e);
+                    }
                 }
             }
         } else {

--- a/crates/orchestrator/src/plugins/node_groups/mod.rs
+++ b/crates/orchestrator/src/plugins/node_groups/mod.rs
@@ -624,6 +624,7 @@ impl NodeGroupsPlugin {
                 for plugin in plugins.iter() {
                     let group_clone = group.clone();
                     let plugin_clone = plugin.clone();
+                    #[cfg(test)]
                     tokio::spawn(async move {
                         if let Err(e) = plugin_clone
                             .send_group_created(
@@ -634,6 +635,18 @@ impl NodeGroupsPlugin {
                             .await
                         {
                             error!("Failed to send group created webhook: {e}");
+                        }
+                    });
+                    #[cfg(not(test))]
+                    tokio::spawn(async move {
+                        if let Err(e) = plugin_clone
+                            .send_group_created(
+                                group_clone.id.to_string(),
+                                group_clone.configuration_name.to_string(),
+                                group_clone.nodes.iter().cloned().collect(),
+                            )
+                        {
+                            error!("Failed to send group created webhook: {}", e);
                         }
                     });
                 }
@@ -981,20 +994,20 @@ impl NodeGroupsPlugin {
         }
 
         // Send webhook notifications
-        self.send_merge_webhooks(groups_to_merge, &merged_group)
-            .await;
+        self.send_merge_webhooks(groups_to_merge, &merged_group);
 
         Ok(Some((merged_group, group_ids_to_dissolve)))
     }
 
     /// Send webhook notifications for group merging
-    async fn send_merge_webhooks(&self, dissolved_groups: &[NodeGroup], merged_group: &NodeGroup) {
+    fn send_merge_webhooks(&self, dissolved_groups: &[NodeGroup], merged_group: &NodeGroup) {
         if let Some(plugins) = &self.webhook_plugins {
             // Send dissolved notifications
             for group in dissolved_groups {
                 for plugin in plugins.iter() {
                     let plugin_clone = plugin.clone();
                     let group_clone = group.clone();
+                    #[cfg(test)]
                     tokio::spawn(async move {
                         if let Err(e) = plugin_clone
                             .send_group_destroyed(
@@ -1007,6 +1020,18 @@ impl NodeGroupsPlugin {
                             error!("Failed to send group dissolved webhook: {e}");
                         }
                     });
+                    #[cfg(not(test))]
+                    tokio::spawn(async move {
+                        if let Err(e) = plugin_clone
+                            .send_group_destroyed(
+                                group_clone.id,
+                                group_clone.configuration_name,
+                                group_clone.nodes.iter().cloned().collect(),
+                            )
+                        {
+                            error!("Failed to send group dissolved webhook: {}", e);
+                        }
+                    });
                 }
             }
 
@@ -1014,6 +1039,7 @@ impl NodeGroupsPlugin {
             for plugin in plugins.iter() {
                 let plugin_clone = plugin.clone();
                 let group_clone = merged_group.clone();
+                #[cfg(test)]
                 tokio::spawn(async move {
                     if let Err(e) = plugin_clone
                         .send_group_created(
@@ -1024,6 +1050,18 @@ impl NodeGroupsPlugin {
                         .await
                     {
                         error!("Failed to send group created webhook: {e}");
+                    }
+                });
+                #[cfg(not(test))]
+                tokio::spawn(async move {
+                    if let Err(e) = plugin_clone
+                        .send_group_created(
+                            group_clone.id,
+                            group_clone.configuration_name,
+                            group_clone.nodes.iter().cloned().collect(),
+                        )
+                    {
+                        error!("Failed to send group created webhook: {}", e);
                     }
                 });
             }
@@ -1100,6 +1138,7 @@ impl NodeGroupsPlugin {
                 for plugin in plugins.iter() {
                     let plugin_clone = plugin.clone();
                     let group_clone = group.clone();
+                    #[cfg(test)]
                     tokio::spawn(async move {
                         if let Err(e) = plugin_clone
                             .send_group_destroyed(
@@ -1110,6 +1149,18 @@ impl NodeGroupsPlugin {
                             .await
                         {
                             error!("Failed to send group dissolved webhook: {e}");
+                        }
+                    });
+                    #[cfg(not(test))]
+                    tokio::spawn(async move {
+                        if let Err(e) = plugin_clone
+                            .send_group_destroyed(
+                                group_clone.id.to_string(),
+                                group_clone.configuration_name.to_string(),
+                                group_clone.nodes.iter().cloned().collect(),
+                            )
+                        {
+                            error!("Failed to send group dissolved webhook: {}", e);
                         }
                     });
                 }

--- a/crates/orchestrator/src/plugins/node_groups/mod.rs
+++ b/crates/orchestrator/src/plugins/node_groups/mod.rs
@@ -624,28 +624,12 @@ impl NodeGroupsPlugin {
                 for plugin in plugins.iter() {
                     let group_clone = group.clone();
                     let plugin_clone = plugin.clone();
-                    #[cfg(test)]
                     tokio::spawn(async move {
-                        if let Err(e) = plugin_clone
-                            .send_group_created(
-                                group_clone.id.to_string(),
-                                group_clone.configuration_name.to_string(),
-                                group_clone.nodes.iter().cloned().collect(),
-                            )
-                            .await
-                        {
-                            error!("Failed to send group created webhook: {e}");
-                        }
-                    });
-                    #[cfg(not(test))]
-                    tokio::spawn(async move {
-                        if let Err(e) = plugin_clone
-                            .send_group_created(
-                                group_clone.id.to_string(),
-                                group_clone.configuration_name.to_string(),
-                                group_clone.nodes.iter().cloned().collect(),
-                            )
-                        {
+                        if let Err(e) = plugin_clone.send_group_created(
+                            group_clone.id.to_string(),
+                            group_clone.configuration_name.to_string(),
+                            group_clone.nodes.iter().cloned().collect(),
+                        ) {
                             error!("Failed to send group created webhook: {}", e);
                         }
                     });
@@ -1007,28 +991,12 @@ impl NodeGroupsPlugin {
                 for plugin in plugins.iter() {
                     let plugin_clone = plugin.clone();
                     let group_clone = group.clone();
-                    #[cfg(test)]
                     tokio::spawn(async move {
-                        if let Err(e) = plugin_clone
-                            .send_group_destroyed(
-                                group_clone.id,
-                                group_clone.configuration_name,
-                                group_clone.nodes.iter().cloned().collect(),
-                            )
-                            .await
-                        {
-                            error!("Failed to send group dissolved webhook: {e}");
-                        }
-                    });
-                    #[cfg(not(test))]
-                    tokio::spawn(async move {
-                        if let Err(e) = plugin_clone
-                            .send_group_destroyed(
-                                group_clone.id,
-                                group_clone.configuration_name,
-                                group_clone.nodes.iter().cloned().collect(),
-                            )
-                        {
+                        if let Err(e) = plugin_clone.send_group_destroyed(
+                            group_clone.id,
+                            group_clone.configuration_name,
+                            group_clone.nodes.iter().cloned().collect(),
+                        ) {
                             error!("Failed to send group dissolved webhook: {}", e);
                         }
                     });
@@ -1039,28 +1007,12 @@ impl NodeGroupsPlugin {
             for plugin in plugins.iter() {
                 let plugin_clone = plugin.clone();
                 let group_clone = merged_group.clone();
-                #[cfg(test)]
                 tokio::spawn(async move {
-                    if let Err(e) = plugin_clone
-                        .send_group_created(
-                            group_clone.id,
-                            group_clone.configuration_name,
-                            group_clone.nodes.iter().cloned().collect(),
-                        )
-                        .await
-                    {
-                        error!("Failed to send group created webhook: {e}");
-                    }
-                });
-                #[cfg(not(test))]
-                tokio::spawn(async move {
-                    if let Err(e) = plugin_clone
-                        .send_group_created(
-                            group_clone.id,
-                            group_clone.configuration_name,
-                            group_clone.nodes.iter().cloned().collect(),
-                        )
-                    {
+                    if let Err(e) = plugin_clone.send_group_created(
+                        group_clone.id,
+                        group_clone.configuration_name,
+                        group_clone.nodes.iter().cloned().collect(),
+                    ) {
                         error!("Failed to send group created webhook: {}", e);
                     }
                 });
@@ -1138,28 +1090,12 @@ impl NodeGroupsPlugin {
                 for plugin in plugins.iter() {
                     let plugin_clone = plugin.clone();
                     let group_clone = group.clone();
-                    #[cfg(test)]
                     tokio::spawn(async move {
-                        if let Err(e) = plugin_clone
-                            .send_group_destroyed(
-                                group_clone.id.to_string(),
-                                group_clone.configuration_name.to_string(),
-                                group_clone.nodes.iter().cloned().collect(),
-                            )
-                            .await
-                        {
-                            error!("Failed to send group dissolved webhook: {e}");
-                        }
-                    });
-                    #[cfg(not(test))]
-                    tokio::spawn(async move {
-                        if let Err(e) = plugin_clone
-                            .send_group_destroyed(
-                                group_clone.id.to_string(),
-                                group_clone.configuration_name.to_string(),
-                                group_clone.nodes.iter().cloned().collect(),
-                            )
-                        {
+                        if let Err(e) = plugin_clone.send_group_destroyed(
+                            group_clone.id.to_string(),
+                            group_clone.configuration_name.to_string(),
+                            group_clone.nodes.iter().cloned().collect(),
+                        ) {
                             error!("Failed to send group dissolved webhook: {}", e);
                         }
                     });

--- a/crates/orchestrator/src/status_update/mod.rs
+++ b/crates/orchestrator/src/status_update/mod.rs
@@ -66,7 +66,7 @@ impl NodeStatusUpdater {
     }
 
     #[cfg(test)]
-    async fn is_node_in_pool(&self, _: &OrchestratorNode) -> bool {
+    fn is_node_in_pool(&self, _: &OrchestratorNode) -> bool {
         true
     }
 
@@ -85,6 +85,9 @@ impl NodeStatusUpdater {
         &self,
         node: &OrchestratorNode,
     ) -> Result<(), anyhow::Error> {
+        #[cfg(test)]
+        let node_in_pool = self.is_node_in_pool(node);
+        #[cfg(not(test))]
         let node_in_pool = self.is_node_in_pool(node).await;
         if node_in_pool {
             match self
@@ -115,6 +118,9 @@ impl NodeStatusUpdater {
         let nodes = self.store_context.node_store.get_nodes().await?;
         for node in nodes {
             if node.status == NodeStatus::Dead {
+                #[cfg(test)]
+                let node_in_pool = self.is_node_in_pool(&node);
+                #[cfg(not(test))]
                 let node_in_pool = self.is_node_in_pool(&node).await;
                 debug!("Node {:?} is in pool: {}", node.address, node_in_pool);
                 if node_in_pool {
@@ -151,6 +157,9 @@ impl NodeStatusUpdater {
                 .get_unhealthy_counter(&node.address)
                 .await?;
 
+            #[cfg(test)]
+            let is_node_in_pool = self.is_node_in_pool(&node);
+            #[cfg(not(test))]
             let is_node_in_pool = self.is_node_in_pool(&node).await;
             let mut status_changed = false;
             let mut new_status = node.status.clone();

--- a/crates/shared/src/web3/contracts/implementations/compute_pool_contract.rs
+++ b/crates/shared/src/web3/contracts/implementations/compute_pool_contract.rs
@@ -404,7 +404,7 @@ impl ComputePool<WalletProvider> {
         Ok(result)
     }
 
-    pub async fn build_work_submission_call(
+    pub fn build_work_submission_call(
         &self,
         pool_id: U256,
         node: Address,

--- a/crates/validator/src/validators/synthetic_data/chain_operations.rs
+++ b/crates/validator/src/validators/synthetic_data/chain_operations.rs
@@ -1,6 +1,21 @@
 use super::*;
 
 impl SyntheticDataValidator<WalletProvider> {
+    #[cfg(test)]
+    pub fn soft_invalidate_work(&self, work_key: &str) -> Result<(), Error> {
+        info!("Soft invalidating work: {}", work_key);
+
+        if self.disable_chain_invalidation {
+            info!("Chain invalidation is disabled, skipping work soft invalidation");
+            return Ok(());
+        }
+
+        info!("Test mode: skipping actual work soft invalidation");
+        let _ = &self.prime_network;
+        Ok(())
+    }
+
+    #[cfg(not(test))]
     pub async fn soft_invalidate_work(&self, work_key: &str) -> Result<(), Error> {
         info!("Soft invalidating work: {work_key}");
 
@@ -9,45 +24,54 @@ impl SyntheticDataValidator<WalletProvider> {
             return Ok(());
         }
 
-        // Special case for tests - skip actual blockchain interaction
-        #[cfg(test)]
+        let work_info = self
+            .get_work_info_from_redis(work_key)
+            .await?
+            .ok_or_else(|| Error::msg("Work info not found for soft invalidation"))?;
+        let work_key_bytes = hex::decode(work_key)
+            .map_err(|e| Error::msg(format!("Failed to decode hex work key: {}", e)))?;
+
+        // Create 64-byte payload: work_key (32 bytes) + work_units (32 bytes)
+        let mut data = Vec::with_capacity(64);
+        data.extend_from_slice(&work_key_bytes);
+
+        // Convert work_units to 32-byte representation
+        let work_units_bytes = work_info.work_units.to_be_bytes::<32>();
+        data.extend_from_slice(&work_units_bytes);
+
+        match self
+            .prime_network
+            .soft_invalidate_work(self.pool_id, data)
+            .await
         {
-            info!("Test mode: skipping actual work soft invalidation");
-            let _ = &self.prime_network;
-            Ok(())
-        }
-
-        #[cfg(not(test))]
-        {
-            let work_info = self
-                .get_work_info_from_redis(work_key)
-                .await?
-                .ok_or_else(|| Error::msg("Work info not found for soft invalidation"))?;
-            let work_key_bytes = hex::decode(work_key)
-                .map_err(|e| Error::msg(format!("Failed to decode hex work key: {e}")))?;
-
-            // Create 64-byte payload: work_key (32 bytes) + work_units (32 bytes)
-            let mut data = Vec::with_capacity(64);
-            data.extend_from_slice(&work_key_bytes);
-
-            // Convert work_units to 32-byte representation
-            let work_units_bytes = work_info.work_units.to_be_bytes::<32>();
-            data.extend_from_slice(&work_units_bytes);
-
-            match self
-                .prime_network
-                .soft_invalidate_work(self.pool_id, data)
-                .await
-            {
-                Ok(_) => Ok(()),
-                Err(e) => {
-                    error!("Failed to soft invalidate work {work_key}: {e}");
-                    Err(Error::msg(format!("Failed to soft invalidate work: {e}")))
-                }
+            Ok(_) => Ok(()),
+            Err(e) => {
+                error!("Failed to soft invalidate work {}: {}", work_key, e);
+                Err(Error::msg(format!("Failed to soft invalidate work: {}", e)))
             }
         }
     }
 
+    #[cfg(test)]
+    pub fn invalidate_work(&self, work_key: &str) -> Result<(), Error> {
+        info!("Invalidating work: {}", work_key);
+
+        if let Some(metrics) = &self.metrics {
+            metrics.record_work_key_invalidation();
+        }
+
+        if self.disable_chain_invalidation {
+            info!("Chain invalidation is disabled, skipping work invalidation");
+            return Ok(());
+        }
+
+        info!("Test mode: skipping actual work invalidation");
+        let _ = &self.prime_network;
+        let _ = &self.penalty;
+        Ok(())
+    }
+
+    #[cfg(not(test))]
     pub async fn invalidate_work(&self, work_key: &str) -> Result<(), Error> {
         info!("Invalidating work: {work_key}");
 
@@ -60,28 +84,17 @@ impl SyntheticDataValidator<WalletProvider> {
             return Ok(());
         }
 
-        #[cfg(test)]
+        let data = hex::decode(work_key)
+            .map_err(|e| Error::msg(format!("Failed to decode hex work key: {}", e)))?;
+        match self
+            .prime_network
+            .invalidate_work(self.pool_id, self.penalty, data)
+            .await
         {
-            info!("Test mode: skipping actual work invalidation");
-            let _ = &self.prime_network;
-            let _ = &self.penalty;
-            Ok(())
-        }
-
-        #[cfg(not(test))]
-        {
-            let data = hex::decode(work_key)
-                .map_err(|e| Error::msg(format!("Failed to decode hex work key: {e}")))?;
-            match self
-                .prime_network
-                .invalidate_work(self.pool_id, self.penalty, data)
-                .await
-            {
-                Ok(_) => Ok(()),
-                Err(e) => {
-                    error!("Failed to invalidate work {work_key}: {e}");
-                    Err(Error::msg(format!("Failed to invalidate work: {e}")))
-                }
+            Ok(_) => Ok(()),
+            Err(e) => {
+                error!("Failed to invalidate work {}: {}", work_key, e);
+                Err(Error::msg(format!("Failed to invalidate work: {}", e)))
             }
         }
     }
@@ -92,7 +105,13 @@ impl SyntheticDataValidator<WalletProvider> {
         invalidation_type: InvalidationType,
     ) -> Result<(), Error> {
         match invalidation_type {
+            #[cfg(test)]
+            InvalidationType::Soft => self.soft_invalidate_work(work_key),
+            #[cfg(not(test))]
             InvalidationType::Soft => self.soft_invalidate_work(work_key).await,
+            #[cfg(test)]
+            InvalidationType::Hard => self.invalidate_work(work_key),
+            #[cfg(not(test))]
             InvalidationType::Hard => self.invalidate_work(work_key).await,
         }
     }

--- a/crates/validator/src/validators/synthetic_data/mod.rs
+++ b/crates/validator/src/validators/synthetic_data/mod.rs
@@ -529,6 +529,11 @@ impl SyntheticDataValidator<WalletProvider> {
         const MAX_ATTEMPTS: i64 = 60;
         if attempts >= MAX_ATTEMPTS {
             // If we've tried too many times, soft invalidate the work and update its status
+            #[cfg(test)]
+            if let Err(_e) = self.soft_invalidate_work(work_key) {
+                // Test mode: error handling skipped
+            }
+            #[cfg(not(test))]
             if let Err(e) = self.soft_invalidate_work(work_key).await {
                 error!(
                     "Failed to soft invalidate work after max filename resolution attempts: {e}"
@@ -1009,7 +1014,7 @@ impl SyntheticDataValidator<WalletProvider> {
         Ok(rejected_nodes)
     }
 
-    async fn handle_group_toploc_acceptance(
+    fn handle_group_toploc_acceptance(
         &self,
         group: &ToplocGroup,
         status: &GroupValidationResult,
@@ -1045,15 +1050,14 @@ impl SyntheticDataValidator<WalletProvider> {
                     total_claimed_units,
                     node_work_units,
                     output_flops_u256,
-                )
-                .await?;
+                )?;
             Ok(nodes_with_wrong_work_unit_claims)
         } else {
             Ok(Vec::new())
         }
     }
 
-    async fn handle_work_units_mismatch(
+    fn handle_work_units_mismatch(
         &self,
         group: &ToplocGroup,
         status: &GroupValidationResult,
@@ -1297,8 +1301,7 @@ impl SyntheticDataValidator<WalletProvider> {
                     total_claimed_units,
                     &node_work_units,
                     &toploc_config_name,
-                )
-                .await?;
+                )?;
             nodes_with_wrong_work_unit_claims.extend(wrong_claim_nodes);
         }
 
@@ -1563,6 +1566,11 @@ impl SyntheticDataValidator<WalletProvider> {
 
                         for work_key in work_keys {
                             // Soft invalidate (less penalty than hard invalidation)
+                            #[cfg(test)]
+                            if let Err(_e) = self.soft_invalidate_work(&work_key) {
+                                // Test mode: error handling skipped
+                            }
+                            #[cfg(not(test))]
                             if let Err(e) = self.soft_invalidate_work(&work_key).await {
                                 error!("Failed to soft invalidate work key {work_key}: {e}");
                             } else {

--- a/crates/validator/src/validators/synthetic_data/mod.rs
+++ b/crates/validator/src/validators/synthetic_data/mod.rs
@@ -1043,14 +1043,13 @@ impl SyntheticDataValidator<WalletProvider> {
         }
 
         if !work_units_match {
-            let nodes_with_wrong_work_unit_claims = self
-                .handle_work_units_mismatch(
-                    group,
-                    status,
-                    total_claimed_units,
-                    node_work_units,
-                    output_flops_u256,
-                )?;
+            let nodes_with_wrong_work_unit_claims = self.handle_work_units_mismatch(
+                group,
+                status,
+                total_claimed_units,
+                node_work_units,
+                output_flops_u256,
+            )?;
             Ok(nodes_with_wrong_work_unit_claims)
         } else {
             Ok(Vec::new())
@@ -1294,14 +1293,13 @@ impl SyntheticDataValidator<WalletProvider> {
             let rejected_nodes = self.handle_group_toploc_rejection(&group, &status).await?;
             toploc_nodes_to_invalidate.extend(rejected_nodes);
         } else if status.status == ValidationResult::Accept {
-            let wrong_claim_nodes = self
-                .handle_group_toploc_acceptance(
-                    &group,
-                    &status,
-                    total_claimed_units,
-                    &node_work_units,
-                    &toploc_config_name,
-                )?;
+            let wrong_claim_nodes = self.handle_group_toploc_acceptance(
+                &group,
+                &status,
+                total_claimed_units,
+                &node_work_units,
+                &toploc_config_name,
+            )?;
             nodes_with_wrong_work_unit_claims.extend(wrong_claim_nodes);
         }
 

--- a/crates/validator/src/validators/synthetic_data/mod.rs
+++ b/crates/validator/src/validators/synthetic_data/mod.rs
@@ -1567,6 +1567,20 @@ impl SyntheticDataValidator<WalletProvider> {
                             #[cfg(test)]
                             if let Err(_e) = self.soft_invalidate_work(&work_key) {
                                 // Test mode: error handling skipped
+                            } else {
+                                // Mark work as soft invalidated due to incomplete group
+                                if let Err(e) = self
+                                    .update_work_validation_status(
+                                        &work_key,
+                                        &ValidationResult::IncompleteGroup,
+                                    )
+                                    .await
+                                {
+                                    error!(
+                                        "Failed to update work validation status for {}: {}",
+                                        work_key, e
+                                    );
+                                }
                             }
                             #[cfg(not(test))]
                             if let Err(e) = self.soft_invalidate_work(&work_key).await {

--- a/crates/validator/src/validators/synthetic_data/tests/mod.rs
+++ b/crates/validator/src/validators/synthetic_data/tests/mod.rs
@@ -1016,7 +1016,7 @@ async fn test_incomplete_group_status_tracking() -> Result<(), Error> {
     assert_eq!(work_keys.len(), 1);
 
     // Soft invalidate and set status to IncompleteGroup
-    validator.soft_invalidate_work(FILE_SHA_1).await?;
+    validator.soft_invalidate_work(FILE_SHA_1)?;
     validator
         .update_work_validation_status(FILE_SHA_1, &ValidationResult::IncompleteGroup)
         .await?;

--- a/crates/worker/src/cli/command.rs
+++ b/crates/worker/src/cli/command.rs
@@ -688,8 +688,8 @@ pub async fn execute_command(
                 }
             };
 
-            if let Err(e) = p2p_service.start().await {
-                error!("❌ Failed to start P2P listener: {e}");
+            if let Err(e) = p2p_service.start() {
+                error!("❌ Failed to start P2P listener: {}", e);
                 std::process::exit(1);
             }
 

--- a/crates/worker/src/docker/taskbridge/bridge.rs
+++ b/crates/worker/src/docker/taskbridge/bridge.rs
@@ -85,7 +85,7 @@ impl TaskBridge {
         }
         Ok(())
     }
-    async fn handle_file_upload(self: Arc<Self>, json_str: &str) -> Result<()> {
+    fn handle_file_upload(self: Arc<Self>, json_str: &str) -> Result<()> {
         debug!("Handling file upload");
         if let Ok(file_info) = serde_json::from_str::<serde_json::Value>(json_str) {
             let task_id = file_info["task_id"].as_str().unwrap_or("unknown");
@@ -175,8 +175,8 @@ impl TaskBridge {
     async fn handle_message(self: Arc<Self>, json_str: &str) -> Result<()> {
         debug!("Extracted JSON object: {json_str}");
         if json_str.contains("output/save_path") {
-            if let Err(e) = self.handle_file_upload(json_str).await {
-                error!("Failed to handle file upload: {e}");
+            if let Err(e) = self.handle_file_upload(json_str) {
+                error!("Failed to handle file upload: {}", e);
             }
         } else {
             debug!("Processing metric message");

--- a/crates/worker/src/docker/taskbridge/file_handler.rs
+++ b/crates/worker/src/docker/taskbridge/file_handler.rs
@@ -356,7 +356,6 @@ pub async fn handle_file_validation(
             decoded_sha.to_vec(),
             U256::from(work_units),
         )
-        .await
         .unwrap();
 
     let tx = retry_call(call, 20, provider.clone(), None)

--- a/crates/worker/src/p2p/service.rs
+++ b/crates/worker/src/p2p/service.rs
@@ -143,7 +143,7 @@ impl P2PService {
         Ok(endpoint)
     }
     /// Start accepting incoming connections with automatic recovery
-    pub async fn start(&self) -> Result<()> {
+    pub fn start(&self) -> Result<()> {
         let service = Arc::new(self.clone());
         let cancellation_token = self.cancellation_token.clone();
 
@@ -696,7 +696,7 @@ mod tests {
         let random_nonce = rand_v8::thread_rng().gen::<u64>();
 
         tokio::spawn(async move {
-            service.start().await.unwrap();
+            service.start().unwrap();
         });
 
         let ping = P2PMessage::Ping {
@@ -723,7 +723,7 @@ mod tests {
         let addresses = service.listening_addresses().to_vec();
 
         tokio::spawn(async move {
-            service.start().await.unwrap();
+            service.start().unwrap();
         });
 
         let ping = P2PMessage::Ping {


### PR DESCRIPTION
fix clippy's `unused_async` warnings by removing unused async from functions and refactoring into test-specific functions if necessary.

i'm not a huge fan of the changes in `crates/validator/src/validators/synthetic_data/chain_operations.rs`, but this will likely involve larger test refactors to remove all the `#[cfg]`s, which i can tackle later.