### PR TITLE
fix: increase pending transaction timeout

### DIFF
--- a/crates/shared/src/web3/contracts/helpers/utils.rs
+++ b/crates/shared/src/web3/contracts/helpers/utils.rs
@@ -73,7 +73,7 @@ where
         match call.clone().send().await {
             Ok(result) => {
                 debug!("Transaction sent, waiting for confirmation...");
-                tx_hash = Some(result.tx_hash().clone());
+                tx_hash = Some(*result.tx_hash());
 
                 match result
                     .with_timeout(Some(PENDING_TRANSACTION_TIMEOUT))

--- a/crates/shared/src/web3/contracts/helpers/utils.rs
+++ b/crates/shared/src/web3/contracts/helpers/utils.rs
@@ -9,7 +9,7 @@ use alloy::{
 };
 use anyhow::Result;
 use log::{debug, info, warn};
-use tokio::time::{timeout, Duration};
+use tokio::time::Duration;
 
 use crate::web3::wallet::WalletProvider;
 
@@ -73,7 +73,7 @@ where
         match call.clone().send().await {
             Ok(result) => {
                 debug!("Transaction sent, waiting for confirmation...");
-                tx_hash = Some(result.tx_hash());
+                tx_hash = Some(result.tx_hash().clone());
 
                 match result
                     .with_timeout(Some(PENDING_TRANSACTION_TIMEOUT))


### PR DESCRIPTION
- increase the pending transaction timeout from 30s to 60s.
- also check if the tx was included after the retry loop `sleep`, in which case, return
- based on the chain of errors logs, it appeared the pending transaction was timing out after 30s, so it was then retried with `Retrying with bumped fees...`, however the tx was included in between the time it timed out and when the retry was started, so the second submission failed

closes #597
closes #596