### PR TITLE
fix: change default task bridge socket file to be in home dir

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3276,6 +3276,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "homedir"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bdbbd5bc8c5749697ccaa352fa45aff8730cf21c68029c0eef1ffed7c3d6ba2"
+dependencies = [
+ "cfg-if",
+ "nix 0.29.0",
+ "widestring",
+ "windows 0.57.0",
+]
+
+[[package]]
 name = "hostname-validator"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8055,6 +8067,16 @@ dependencies = [
 
 [[package]]
 name = "windows"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
+dependencies = [
+ "windows-core 0.57.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows"
 version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
@@ -8079,6 +8101,18 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d"
+dependencies = [
+ "windows-implement 0.57.0",
+ "windows-interface 0.57.0",
+ "windows-result 0.1.2",
  "windows-targets 0.52.6",
 ]
 
@@ -8123,6 +8157,17 @@ dependencies = [
 
 [[package]]
 name = "windows-implement"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "windows-implement"
 version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
@@ -8148,6 +8193,17 @@ name = "windows-implement"
 version = "0.60.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8191,6 +8247,15 @@ dependencies = [
  "windows-result 0.3.2",
  "windows-strings 0.3.1",
  "windows-targets 0.53.0",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -8515,6 +8580,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "hex",
+ "homedir",
  "indicatif",
  "iroh",
  "lazy_static",

--- a/crates/worker/Cargo.toml
+++ b/crates/worker/Cargo.toml
@@ -55,3 +55,4 @@ iroh = { workspace = true }
 rand_v8 = { workspace = true }
 rand_core_v6 = { workspace = true }
 dashmap = "6.1.0"
+homedir = "0.3"

--- a/crates/worker/src/docker/taskbridge/bridge.rs
+++ b/crates/worker/src/docker/taskbridge/bridge.rs
@@ -47,13 +47,10 @@ impl TaskBridge {
         state: Arc<SystemState>,
     ) -> Result<Arc<Self>> {
         let path = match socket_path {
-            Some(path) => {
-                let path = std::path::PathBuf::from(path);
-                path
-            }
+            Some(path) => std::path::PathBuf::from(path),
             None => {
                 let path =
-                    std::env::home_dir().ok_or(anyhow::anyhow!("failed to get home directory"))?;
+                    homedir::my_home()?.ok_or(anyhow::anyhow!("failed to get home directory"))?;
                 path.join(DEFAULT_SOCKET_FILE)
             }
         };
@@ -356,7 +353,8 @@ mod tests {
             None,
             "test_storage_path".to_string(),
             state,
-        ).unwrap();
+        )
+        .unwrap();
 
         // Run the bridge in background
         let bridge_handle = tokio::spawn(async move { bridge.run().await });
@@ -387,7 +385,8 @@ mod tests {
             None,
             "test_storage_path".to_string(),
             state,
-        ).unwrap();
+        )
+        .unwrap();
 
         // Run bridge in background
         let bridge_handle = tokio::spawn(async move { bridge.run().await });
@@ -420,7 +419,8 @@ mod tests {
             None,
             "test_storage_path".to_string(),
             state,
-        ).unwrap();
+        )
+        .unwrap();
 
         let bridge_handle = tokio::spawn(async move { bridge.run().await });
 
@@ -467,7 +467,8 @@ mod tests {
             None,
             "test_storage_path".to_string(),
             state,
-        ).unwrap();
+        )
+        .unwrap();
 
         let bridge_handle = tokio::spawn(async move { bridge.run().await });
 
@@ -514,7 +515,8 @@ mod tests {
             None,
             "test_storage_path".to_string(),
             state,
-        ).unwrap();
+        )
+        .unwrap();
 
         let bridge_handle = tokio::spawn(async move { bridge.run().await });
 

--- a/examples/python/taskbridge_basic.py
+++ b/examples/python/taskbridge_basic.py
@@ -4,10 +4,12 @@ import json
 import os
 import threading
 import platform
+from pathlib import Path
 
 def get_default_socket_path():
     """Returns the default socket path based on the operating system."""
-    return "/tmp/com.prime.worker/metrics.sock" if platform.system() == "Darwin" else "/var/run/com.prime.worker/metrics.sock"
+    home = Path.home()
+    return str(home) + "/prime-worker/com.prime.worker/metrics.sock"
 
 def send_message(metrics, task_id=None):
     """Sends a message to the socket."""


### PR DESCRIPTION
- change the default task bridge socket file to be in the user's home directory
- previously it was in `/tmp`, which is cleared on restart. the container persists on reboot and it tries to recreate the dir since it no longer exists but w root perms, which is not writable by the worker running as a user
- it's now in the user `prime-worker` directory which is persistent